### PR TITLE
Configure CI to execute default rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'db/schema.rb'
     - 'db/seeds.rb'
     - 'bin/**/*'
+    - 'vendor/**/*'
 
 Style/StringLiterals:
   Enabled: false

--- a/app.json
+++ b/app.json
@@ -3,7 +3,10 @@
     "test": {
       "addons": [
         "heroku-postgresql:in-dyno"
-      ]
+      ],
+      "scripts": {
+        "test": "bundle exec rake default"
+      }
     }
   }
 }

--- a/lib/tasks/default.rake
+++ b/lib/tasks/default.rake
@@ -1,0 +1,1 @@
+task default: %i[rubocop spec] if Rails.env.test? || Rails.env.development?

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,0 +1,10 @@
+if Rails.env.development? || Rails.env.test?
+  desc 'Run rubocop - configure in .rubocop.yml'
+  task :rubocop do
+    require 'rubocop/rake_task'
+
+    RuboCop::RakeTask.new(:rubocop) do |t|
+      t.options = ['--display-cop-names']
+    end
+  end
+end


### PR DESCRIPTION
We can only execute one command for tests as part of CI so we need a default rake task that calls both the RuboCop and RSpec rake tasks.