### PR TITLE
Add basic auth

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  http_basic_authenticate_with(
+    name: ENV["BASIC_AUTH_USERNAME"],
+    password: ENV["BASIC_AUTH_PASSWORD"],
+    if: -> { ENV.has_key?("BASIC_AUTH_USERNAME") },
+  )
 end


### PR DESCRIPTION
Until we are ready for the service to be available more widely we want
to slightly restrict access to it. This is to prevent members of the
public finding the application and thinking it's currently a live
service.

We're using basic auth configured with a single set of credentials. This
makes it easy for the team to grant access to the service to anyone
working on it, any stakeholders interested in it, and any user research
participants using it.

The username and password for each environment can be configured using
environment variables set in Heroku.

Once we are confident we know the scope of our beta and how we will
introduce it to users, we will change or remove the authentication
approach.