### PR TITLE
Allow dynamic page titles with a sensible default

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def page_title(title)
+    content_for :page_title, title
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template app-html-class">
   <head>
-    <title>DfeTeachersPaymentService</title>
+    <title>
+      <%= content_for(:page_title) || t(:service_name) %>
+    </title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,4 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  service_name: "Teacher’s Payment Service"


### PR DESCRIPTION
Pages should have unique page titles and this gives us a way to set the
page title for any view by setting the value of page_title in the view
file.

If none is set we will use the service name from the locales file
which this commit also adds.

Wherever the service name appears we should us t(:service_name) so
we can change the service name at any point from a single place.