### PR TITLE
Rubocop-rails gem has been renamed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_gem:
   dxw-utils:
     - dxw-rubocop.yml
-  rubocop-rails:
+  rubocop-rails_config:
     - config/rails.yml
 
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ group :development, :test do
 
   gem 'rspec-rails'
   gem 'capybara'
-  gem 'rubocop-rails'
+  gem 'rubocop-rails_config'
   gem 'dxw-utils', git: 'https://github.com/dxw/dxw-utils'
   gem 'brakeman', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,9 +169,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rails (1.5.0)
+    rubocop-rails_config (0.4.4)
       railties (>= 3.0)
-      rubocop (~> 0.53)
+      rubocop (~> 0.58)
     rubocop-rspec (1.29.1)
       rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
@@ -234,7 +234,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.2)
   rspec-rails
-  rubocop-rails
+  rubocop-rails_config
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
This will get rid of a deprecation warning when running bundle.