### PR TITLE
Add Bullet to RSpec to check for N+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem "capybara"
   gem "brakeman", require: false
   gem "standard"
+  gem "bullet"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,9 @@ GEM
       msgpack (~> 1.0)
     brakeman (4.5.0)
     builder (3.2.3)
+    bullet (5.9.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     capybara (3.16.1)
       addressable
@@ -196,6 +199,7 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.5.0)
+    uniform_notifier (1.12.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -213,6 +217,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   brakeman
+  bullet
   byebug
   capybara
   dxw_govuk_frontend_rails

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ From the dxw utils project:
 
 https://github.com/dxw/dxw-utils
 
+### N+1 query detection
+
+[Bullet](https://github.com/flyerhzm/bullet) runs around each spec. If it detects an N+1 query it will raise an
+exception and the tests will fail.
+
 ## Access
 Both staging and production are protected by HTTP Basic Authentication, these details are pinned in the *dfe-teacher-payments* slack channel or can be found in the *Config Vars* in Heroku.
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,10 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require "rspec/rails"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/bullet.rb
+++ b/spec/support/bullet.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  if Bullet.enable?
+    config.around(:each) do |spec|
+      Bullet.start_request
+
+      spec.run
+
+      Bullet.end_request
+    end
+  end
+end


### PR DESCRIPTION
[Bullet](https://github.com/flyerhzm/bullet) is a gem that detects N+1 queries.

Bullet will raise an exception when it encounters an N+1 query causing the tests to fail. It will start before each spec. 

It is configured to only run in our test environment because running it in development would add unneeded bloat.

RSpec will now autoload all files in the `spec/support` folder. This was done to help make our RSpec configuration more manageable.