### PR TITLE
A Teacher can start a TSLR claim

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,4 +1,6 @@
 class ClaimsController < ApplicationController
+  before_action :send_unstarted_claiments_to_the_start, only: [:show, :update]
+
   def new
   end
 
@@ -25,7 +27,11 @@ class ClaimsController < ApplicationController
   end
 
   def current_claim
-    @current_claim ||= TslrClaim.find(session[:tslr_claim_id])
+    @current_claim ||= TslrClaim.find(session[:tslr_claim_id]) if session.key?(:tslr_claim_id)
   end
   helper_method :current_claim
+
+  def send_unstarted_claiments_to_the_start
+    redirect_to root_url unless current_claim.present?
+  end
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -3,8 +3,31 @@ class ClaimsController < ApplicationController
   end
 
   def create
-    TslrClaim.create!
+    claim = TslrClaim.create!
+    session[:tslr_claim_id] = claim.to_param
 
     redirect_to qts_year_claim_path
   end
+
+  def update
+    current_claim.update_attributes(claim_params)
+    redirect_to claim_school_claim_path
+  end
+
+  def qts_year
+  end
+
+  def claim_school
+  end
+
+  private
+
+  def claim_params
+    params.require(:tslr_claim).permit(:qts_award_year)
+  end
+
+  def current_claim
+    @current_claim ||= TslrClaim.find(session[:tslr_claim_id])
+  end
+  helper_method :current_claim
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,0 +1,10 @@
+class ClaimsController < ApplicationController
+  def new
+  end
+
+  def create
+    TslrClaim.create!
+
+    redirect_to qts_year_claim_path
+  end
+end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -8,22 +8,26 @@ class ClaimsController < ApplicationController
     claim = TslrClaim.create!
     session[:tslr_claim_id] = claim.to_param
 
-    redirect_to claim_path(:qts_year)
+    redirect_to claim_path("qts-year")
   end
 
   def show
-    render params[:slug]
+    render claim_page_template
   end
 
   def update
     current_claim.update_attributes(claim_params)
-    redirect_to claim_path(:claim_school)
+    redirect_to claim_path("claim-school")
   end
 
   private
 
   def claim_params
     params.require(:tslr_claim).permit(:qts_award_year)
+  end
+
+  def claim_page_template
+    params[:slug].underscore
   end
 
   def current_claim

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -6,18 +6,16 @@ class ClaimsController < ApplicationController
     claim = TslrClaim.create!
     session[:tslr_claim_id] = claim.to_param
 
-    redirect_to qts_year_claim_path
+    redirect_to claim_path(:qts_year)
+  end
+
+  def show
+    render params[:slug]
   end
 
   def update
     current_claim.update_attributes(claim_params)
-    redirect_to claim_school_claim_path
-  end
-
-  def qts_year
-  end
-
-  def claim_school
+    redirect_to claim_path(:claim_school)
   end
 
   private

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -16,8 +16,12 @@ class ClaimsController < ApplicationController
   end
 
   def update
-    current_claim.update_attributes(claim_params)
-    redirect_to claim_path("claim-school")
+    current_claim.attributes = claim_params
+    if current_claim.save(context: params[:slug].to_sym)
+      redirect_to claim_path("claim-school")
+    else
+      render claim_page_template
+    end
   end
 
   private

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -1,13 +1,8 @@
 module ClaimsHelper
   def options_for_qts_award_year
-    [
-      ["September 1 2013 - August 31 2014", "2013-2014"],
-      ["September 1 2014 - August 31 2015", "2014-2015"],
-      ["September 1 2015 - August 31 2016", "2015-2016"],
-      ["September 1 2016 - August 31 2017", "2016-2017"],
-      ["September 1 2017 - August 31 2018", "2017-2018"],
-      ["September 1 2018 - August 31 2019", "2018-2019"],
-      ["September 1 2019 - August 31 2020", "2019-2020"],
-    ]
+    TslrClaim::VALID_QTS_YEARS.map do |academic_years|
+      start_year, end_year = academic_years.split("-")
+      ["September 1 #{start_year} - August 31 #{end_year}", academic_years]
+    end
   end
 end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -1,0 +1,13 @@
+module ClaimsHelper
+  def options_for_qts_award_year
+    [
+      ["September 1 2013 - August 31 2014", "2013-2014"],
+      ["September 1 2014 - August 31 2015", "2014-2015"],
+      ["September 1 2015 - August 31 2016", "2015-2016"],
+      ["September 1 2016 - August 31 2017", "2016-2017"],
+      ["September 1 2017 - August 31 2018", "2017-2018"],
+      ["September 1 2018 - August 31 2019", "2018-2019"],
+      ["September 1 2019 - August 31 2020", "2019-2020"],
+    ]
+  end
+end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -1,0 +1,2 @@
+class TslrClaim < ApplicationRecord
+end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -1,2 +1,13 @@
 class TslrClaim < ApplicationRecord
+  VALID_QTS_YEARS = [
+    "2013-2014",
+    "2014-2015",
+    "2015-2016",
+    "2016-2017",
+    "2017-2018",
+    "2018-2019",
+    "2019-2020",
+  ].freeze
+
+  validates :qts_award_year, inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}, on: :"qts-year"
 end

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -1,0 +1,9 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Which school were you employed at between 6 April XXXX and 5 April XXXX?
+    </h1>
+
+    <p class="govuk-body">Coming next...</p>
+  </div>
+</div>

--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -35,6 +35,6 @@
       By claiming, you are confirming that you consent to us contacting the school.
     </p>
 
-    <%= button_to 'Agree and continue', claim_path, method: :post, class: "govuk-button" %>
+    <%= button_to 'Agree and continue', claims_path, method: :post, class: "govuk-button" %>
   </div>
 </div>

--- a/app/views/claims/new.html.erb
+++ b/app/views/claims/new.html.erb
@@ -1,0 +1,40 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Consent to us contacting your school
+    </h1>
+
+    <p class="govuk-body">
+      To claim your student loan payments back we will contact the school you tell
+      us about in this claim to confirm:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        that you were employed to teach there
+      </li>
+      <li>
+        that you spent most of your time teaching 11 to 16 year olds or, if you
+        were on leave or off sick, that you were employed to teach this age range
+      </li>
+      <li>
+        how much student loan you paid back through your wages while you were there
+      </li>
+      <li>
+        the subject that you were employed to teach, if you worked at a state-
+        funded school or academy
+      </li>
+      <li>
+        how much of your time was spent teaching that subject, if you worked at a
+        state-funded school or academy
+      </li>
+    </ul>
+    <p class="govuk-body">
+      We must do this to process your claim.
+    </p>
+    <p class="govuk-body">
+      By claiming, you are confirming that you consent to us contacting the school.
+    </p>
+
+    <%= button_to 'Agree and continue', claim_path, method: :post, class: "govuk-button" %>
+  </div>
+</div>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -1,8 +1,22 @@
-<h1 class="govuk-heading-xl">
-  Which academic year were you awarded qualified teacher status (QTS)?
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <h1 class="govuk-heading-xl">
+        <%= form.label :qts_award_year, "Which academic year were you awarded qualified teacher status (QTS)?" %>
+      </h1>
 
-<p class="govuk-body">
-  You are only eligable to claim back student loan repayments if you qualified
-  after September 1st 2013.
-</p>
+      <span id="tslr_claim_qts_award_year-hint" class="govuk-hint">
+        You are only eligable to claim back student loan repayments if you qualified
+        on or after September 1st 2013.
+      </span>
+
+      <div class="govuk-form-group">
+        <%= form.select :qts_award_year, options_for_qts_award_year, { include_blank: true }, class: "govuk-select" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -5,6 +5,8 @@
         <%= form.label :qts_award_year, "Which academic year were you awarded qualified teacher status (QTS)?" %>
       </h1>
 
+      <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
       <span id="tslr_claim_qts_award_year-hint" class="govuk-hint">
         You are only eligable to claim back student loan repayments if you qualified
         on or after September 1st 2013.

--- a/app/views/claims/qts_year.html.erb
+++ b/app/views/claims/qts_year.html.erb
@@ -1,0 +1,8 @@
+<h1 class="govuk-heading-xl">
+  Which academic year were you awarded qualified teacher status (QTS)?
+</h1>
+
+<p class="govuk-body">
+  You are only eligable to claim back student loan repayments if you qualified
+  after September 1st 2013.
+</p>

--- a/app/views/shared/_error_summary.html.erb
+++ b/app/views/shared/_error_summary.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    There is a problem
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <% instance.errors.each do |attribute, error| %>
+        <li><%= link_to error, "##{instance.class.model_name.singular}_#{attribute}" %></li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "d295fbb2c23775e4923257fd12543b72b959f0b21fd678dc50373e1c62e2ce24",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/claims_controller.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => params[:slug], {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ClaimsController",
+        "method": "show"
+      },
+      "user_input": "params[:slug]",
+      "confidence": "High",
+      "note": "We are using a routing constraint to only route slugs that are in a whitelist, making this a false-positive"
+    }
+  ],
+  "updated": "2019-04-29 15:28:26 +0100",
+  "brakeman_version": "4.5.0"
+}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 
+  # Raise an exception if parameters that are not explicitly permitted are found
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,9 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
+  # Raise an exception if parameters that are not explicitly permitted are found
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Store uploaded files on the local file system in a temporary directory
   config.active_storage.service = :test
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,4 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  service_name: "Teacher’s Payment Service"
+  service_name: "Teachers: claim back student loan repayments"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get "start/index"
   root "claims#new"
 
-  constraints slug: /qts_year|claim_school/ do
+  constraints slug: /qts-year|claim-school/ do
     resources :claims, only: [:new, :create, :show, :update], param: :slug
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   get "start/index"
   root "claims#new"
 
-  resources :claims, only: [:new, :create, :show, :update], param: :slug
+  constraints slug: /qts_year|claim_school/ do
+    resources :claims, only: [:new, :create, :show, :update], param: :slug
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,5 @@ Rails.application.routes.draw do
   get "start/index"
   root "claims#new"
 
-  resource :claim, only: [:new, :create, :update] do
-    member do
-      get :qts_year
-      get :claim_school
-    end
-  end
+  resources :claims, only: [:new, :create, :show, :update], param: :slug
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,10 @@ Rails.application.routes.draw do
   get "start/index"
   root "claims#new"
 
-  resource :claim, only: [:new, :create] do
+  resource :claim, only: [:new, :create, :update] do
     member do
       get :qts_year
+      get :claim_school
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get "start/index"
-  root "start#index"
+  root "claims#new"
+
+  resource :claim, only: [:new, :create] do
+    member do
+      get :qts_year
+    end
+  end
 end

--- a/db/migrate/20190416090236_create_tslr_claims.rb
+++ b/db/migrate/20190416090236_create_tslr_claims.rb
@@ -1,6 +1,8 @@
 class CreateTslrClaims < ActiveRecord::Migration[5.2]
   def change
-    create_table :tslr_claims do |t|
+    create_table :tslr_claims, id: :uuid do |t|
+      t.string :qts_award_year
+
       t.timestamps
     end
   end

--- a/db/migrate/20190416090236_create_tslr_claims.rb
+++ b/db/migrate/20190416090236_create_tslr_claims.rb
@@ -1,0 +1,7 @@
+class CreateTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tslr_claims do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,4 +40,9 @@ ActiveRecord::Schema.define(version: 2019_04_16_104000) do
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
+  create_table "tslr_claims", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,8 @@ ActiveRecord::Schema.define(version: 2019_04_16_104000) do
     t.index ["urn"], name: "index_schools_on_urn", unique: true
   end
 
-  create_table "tslr_claims", force: :cascade do |t|
+  create_table "tslr_claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "qts_award_year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -15,4 +15,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(claim.reload.qts_award_year).to eql("2014-2015")
     expect(page).to have_text("Which school were you employed at between")
   end
+
+  scenario "Teacher cannot go to mid-claim page before starting a claim" do
+    visit claim_path(:qts_year)
+    expect(page).to have_current_path(root_path)
+  end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -6,6 +6,13 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     click_on "Agree and continue"
 
+    claim = TslrClaim.order(:created_at).last
+
     expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
+    click_on "Continue"
+
+    expect(claim.reload.qts_award_year).to eql("2014-2015")
+    expect(page).to have_text("Which school were you employed at between")
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   end
 
   scenario "Teacher cannot go to mid-claim page before starting a claim" do
-    visit claim_path(:qts_year)
+    visit claim_path("qts-year")
     expect(page).to have_current_path(root_path)
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.feature "Teacher Student Loan Repayments claims" do
+  scenario "Teacher claims back student loan repayments" do
+    visit root_path
+
+    click_on "Agree and continue"
+
+    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+  end
+end

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe ClaimsHelper do
+  describe "#options_for_qts_award_year" do
+    it "returns an array of the valid years as label/value pairs for use as select options" do
+      expected_options = [
+        ["September 1 2013 - August 31 2014", "2013-2014"],
+        ["September 1 2014 - August 31 2015", "2014-2015"],
+        ["September 1 2015 - August 31 2016", "2015-2016"],
+        ["September 1 2016 - August 31 2017", "2016-2017"],
+        ["September 1 2017 - August 31 2018", "2017-2018"],
+        ["September 1 2018 - August 31 2019", "2018-2019"],
+        ["September 1 2019 - August 31 2020", "2019-2020"],
+      ]
+
+      expect(helper.options_for_qts_award_year).to eq expected_options
+    end
+  end
+end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -1,5 +1,16 @@
 require "rails_helper"
 
 RSpec.describe TslrClaim, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "when saving in the “qts-year” validation context" do
+    let(:custom_validation_context) { :"qts-year" }
+
+    it "validates the qts_award_year is one of the allowable values" do
+      expect(TslrClaim.new).not_to be_valid(custom_validation_context)
+      expect(TslrClaim.new(qts_award_year: "123")).not_to be_valid(custom_validation_context)
+
+      TslrClaim::VALID_QTS_YEARS.each do |academic_year|
+        expect(TslrClaim.new(qts_award_year: academic_year)).to be_valid(custom_validation_context)
+      end
+    end
+  end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe TslrClaim, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe "Claims", type: :request do
+  describe "claims#new request" do
+    it "renders the consent form" do
+      get new_claim_path
+
+      expect(response).to be_successful
+      expect(response.body).to include("Consent to us contacting your school")
+    end
+  end
+
+  describe "claims#create request" do
+    it "creates a new TslrClaim and redirects to the QTS question" do
+      expect { post claim_path }.to change { TslrClaim.count }.by(1)
+
+      expect(response).to redirect_to(qts_year_claim_path)
+    end
+  end
+end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe "Claims", type: :request do
 
         expect(in_progress_claim.qts_award_year).to eq "2014-2015"
       end
+
+      it "makes sure validations appropriate to the context are run" do
+        put claim_path("qts-year"), params: {tslr_claim: {qts_award_year: nil}}
+
+        expect(response.body).to include("Select the academic year you were awarded qualified teacher status")
+      end
     end
 
     context "when a claim hasn’t been started yet" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -17,4 +17,18 @@ RSpec.describe "Claims", type: :request do
       expect(response).to redirect_to(qts_year_claim_path)
     end
   end
+
+  describe "claims#update request" do
+    context "when a claim is already in progress" do
+      let(:in_progress_claim) { TslrClaim.order(:created_at).last }
+
+      before { post claim_path }
+
+      it "updates the claim with the submitted form data" do
+        put claim_path, params: {tslr_claim: {qts_award_year: "2014-2015"}}
+
+        expect(in_progress_claim.qts_award_year).to eq "2014-2015"
+      end
+    end
+  end
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Claims", type: :request do
     it "creates a new TslrClaim and redirects to the QTS question" do
       expect { post claims_path }.to change { TslrClaim.count }.by(1)
 
-      expect(response).to redirect_to(claim_path(:qts_year))
+      expect(response).to redirect_to(claim_path("qts-year"))
     end
   end
 
@@ -25,17 +25,17 @@ RSpec.describe "Claims", type: :request do
       before { post claims_path }
 
       it "renders the requested page in the sequence" do
-        get claim_path(:qts_year)
+        get claim_path("qts-year")
         expect(response.body).to include("Which academic year were you awarded qualified teacher status")
 
-        get claim_path(:claim_school)
+        get claim_path("claim-school")
         expect(response.body).to include("Which school were you employed at")
       end
     end
 
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page" do
-        get claim_path(:qts_year)
+        get claim_path("qts-year")
         expect(:response).to redirect_to(root_path)
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe "Claims", type: :request do
       before { post claims_path }
 
       it "updates the claim with the submitted form data" do
-        put claim_path(:qts_year), params: {tslr_claim: {qts_award_year: "2014-2015"}}
+        put claim_path("qts-year"), params: {tslr_claim: {qts_award_year: "2014-2015"}}
 
         expect(in_progress_claim.qts_award_year).to eq "2014-2015"
       end
@@ -56,7 +56,7 @@ RSpec.describe "Claims", type: :request do
 
     context "when a claim hasn’t been started yet" do
       it "redirects to the start page" do
-        put claim_path(:qts_year), params: {tslr_claim: {qts_award_year: "2014-2015"}}
+        put claim_path("qts-year"), params: {tslr_claim: {qts_award_year: "2014-2015"}}
         expect(:response).to redirect_to(root_path)
       end
     end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -12,9 +12,25 @@ RSpec.describe "Claims", type: :request do
 
   describe "claims#create request" do
     it "creates a new TslrClaim and redirects to the QTS question" do
-      expect { post claim_path }.to change { TslrClaim.count }.by(1)
+      expect { post claims_path }.to change { TslrClaim.count }.by(1)
 
-      expect(response).to redirect_to(qts_year_claim_path)
+      expect(response).to redirect_to(claim_path(:qts_year))
+    end
+  end
+
+  describe "claims#show request" do
+    context "when a claim is already in progress" do
+      let(:in_progress_claim) { TslrClaim.order(:created_at).last }
+
+      before { post claims_path }
+
+      it "renders the requested page in the sequence" do
+        get claim_path(:qts_year)
+        expect(response.body).to include("Which academic year were you awarded qualified teacher status")
+
+        get claim_path(:claim_school)
+        expect(response.body).to include("Which school were you employed at")
+      end
     end
   end
 
@@ -22,10 +38,10 @@ RSpec.describe "Claims", type: :request do
     context "when a claim is already in progress" do
       let(:in_progress_claim) { TslrClaim.order(:created_at).last }
 
-      before { post claim_path }
+      before { post claims_path }
 
       it "updates the claim with the submitted form data" do
-        put claim_path, params: {tslr_claim: {qts_award_year: "2014-2015"}}
+        put claim_path(:qts_year), params: {tslr_claim: {qts_award_year: "2014-2015"}}
 
         expect(in_progress_claim.qts_award_year).to eq "2014-2015"
       end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe "Claims", type: :request do
         expect(response.body).to include("Which school were you employed at")
       end
     end
+
+    context "when a claim hasn’t been started yet" do
+      it "redirects to the start page" do
+        get claim_path(:qts_year)
+        expect(:response).to redirect_to(root_path)
+      end
+    end
   end
 
   describe "claims#update request" do
@@ -44,6 +51,13 @@ RSpec.describe "Claims", type: :request do
         put claim_path(:qts_year), params: {tslr_claim: {qts_award_year: "2014-2015"}}
 
         expect(in_progress_claim.qts_award_year).to eq "2014-2015"
+      end
+    end
+
+    context "when a claim hasn’t been started yet" do
+      it "redirects to the start page" do
+        put claim_path(:qts_year), params: {tslr_claim: {qts_award_year: "2014-2015"}}
+        expect(:response).to redirect_to(root_path)
       end
     end
   end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe "Routes", type: :routing do
+  describe "Claims routing" do
+    it "only routes to pages in the claim sequence" do
+      expect(get: "claims/qts_year").to route_to "claims#show", slug: "qts_year"
+      expect(get: "claims/claim_school").to route_to "claims#show", slug: "claim_school"
+
+      expect(get: "claims/non_existent_page").not_to be_routable
+    end
+  end
+end

--- a/spec/routes/routes_spec.rb
+++ b/spec/routes/routes_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 describe "Routes", type: :routing do
   describe "Claims routing" do
     it "only routes to pages in the claim sequence" do
-      expect(get: "claims/qts_year").to route_to "claims#show", slug: "qts_year"
-      expect(get: "claims/claim_school").to route_to "claims#show", slug: "claim_school"
+      expect(get: "claims/qts-year").to route_to "claims#show", slug: "qts-year"
+      expect(get: "claims/claim-school").to route_to "claims#show", slug: "claim-school"
 
-      expect(get: "claims/non_existent_page").not_to be_routable
+      expect(get: "claims/non-existent-page").not_to be_routable
     end
   end
 end


### PR DESCRIPTION
This is the first step in the claim process for Teacher Student Loan Reimbursements. The aim is to:

- Allow the user to consent before continuing
- Capture the answer to the first question
- Give us a foundation to build out the rest of the journey

For now there is little modelling and abstraction of the multi-page application process as this only implements the first two steps, so the specific URLs/slugs (i.e. 'qts-year' and 'claim-school') are hardcoded for now. I expect this modelling to begin emerging when the next story is worked on (specifying the school that the teacher taught at).

The foundation of this is a RESTful `ClaimsController` that behaves like a [singular resource](https://guides.rubyonrails.org/v5.2/routing.html#singular-resources) for the current in-progress claim. The `show` action is used for the various stages of the claim, with the `slug` representing the current stage.