### PR TITLE
(39) Teacher specifies claim school

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
     diff-lcs (1.3)
-    dxw_govuk_frontend_rails (2.9.0.pre.alpha.1)
+    dxw_govuk_frontend_rails (2.11.0)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (5.0.2)

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -21,7 +21,11 @@ class ClaimsController < ApplicationController
   def update
     current_claim.attributes = claim_params
     if current_claim.save(context: params[:slug].to_sym)
-      redirect_to claim_path("claim-school")
+      if params[:slug] == "qts-year"
+        redirect_to claim_path("claim-school")
+      elsif params[:slug] == "claim-school"
+        redirect_to claim_path("still-teaching")
+      end
     else
       render claim_page_template
     end
@@ -30,7 +34,7 @@ class ClaimsController < ApplicationController
   private
 
   def claim_params
-    params.require(:tslr_claim).permit(:qts_award_year)
+    params.require(:tslr_claim).permit(:qts_award_year, :claim_school_id)
   end
 
   def claim_page_template

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -12,9 +12,7 @@ class ClaimsController < ApplicationController
   end
 
   def show
-    if params[:school_search]
-      @schools = School.search(params[:school_search])
-    end
+    perform_non_js_school_search if params[:school_search]
     render claim_page_template
   end
 
@@ -32,6 +30,14 @@ class ClaimsController < ApplicationController
   end
 
   private
+
+  def perform_non_js_school_search
+    if params[:school_search].length > 3
+      @schools = School.search(params[:school_search])
+    else
+      current_claim.errors.add(:base, "Search for the school name with a minimum of four characters")
+    end
+  end
 
   def claim_params
     params.require(:tslr_claim).permit(:qts_award_year, :claim_school_id)

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -12,6 +12,9 @@ class ClaimsController < ApplicationController
   end
 
   def show
+    if params[:school_search]
+      @schools = School.search(params[:school_search])
+    end
     render claim_page_template
   end
 

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -25,7 +25,7 @@ class ClaimsController < ApplicationController
         redirect_to claim_path("still-teaching")
       end
     else
-      render claim_page_template
+      show
     end
   end
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -73,4 +73,8 @@ class School < ApplicationRecord
   enum phase: PHASES
   enum school_type_group: SCHOOL_TYPE_GROUPS
   enum school_type: SCHOOL_TYPES
+
+  def self.search(search_term)
+    where("name ILIKE ?", "%#{sanitize_sql_like(search_term)}%")
+  end
 end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -77,4 +77,8 @@ class School < ApplicationRecord
   def self.search(search_term)
     where("name ILIKE ?", "%#{sanitize_sql_like(search_term)}%")
   end
+
+  def address
+    [street, locality, town, county, postcode].reject(&:blank?).join(", ")
+  end
 end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -9,5 +9,8 @@ class TslrClaim < ApplicationRecord
     "2019-2020",
   ].freeze
 
+  belongs_to :claim_school, optional: true, class_name: "School"
+  validates :claim_school, presence: {message: "Select a school from the list"}, on: :"claim-school"
+
   validates :qts_award_year, inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}, on: :"qts-year"
 end

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -33,8 +33,9 @@
             <div class="govuk-radios">
               <%= form.collection_radio_buttons :claim_school_id, @schools, :id, :name do |b| %>
                 <div class="govuk-radios__item">
-                  <%= b.radio_button( class: "govuk-radios__input") %>
-                  <%= b.label class: "govuk-label govuk-radios__label"  %>
+                  <%= b.radio_button class: "govuk-radios__input" %>
+                  <%= b.label class: "govuk-label govuk-radios__label govuk-label--s" %>
+                  <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
                 </div>
               <% end %>
             </div>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -4,6 +4,23 @@
       Which school were you employed at between 6 April XXXX and 5 April XXXX?
     </h1>
 
-    <p class="govuk-body">Coming next...</p>
+    <%= form_tag(claim_path("claim-school"), method: :get) do %>
+      <div class="govuk-form-group">
+        <%= label_tag :school_search, "School name", class: "govuk-label" %>
+        <%= text_field_tag :school_search, params[:school_search], class: "govuk-input" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= submit_tag "Search", class: "govuk-button" %>
+      </div>
+    <% end %>
+
+    <% if @schools.present? %>
+      <ul>
+        <% @schools.each do |school| %>
+          <li><%= school.name %></li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 </div>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -4,23 +4,43 @@
       Which school were you employed at between 6 April XXXX and 5 April XXXX?
     </h1>
 
-    <%= form_tag(claim_path("claim-school"), method: :get) do %>
-      <div class="govuk-form-group">
-        <%= label_tag :school_search, "School name", class: "govuk-label" %>
-        <%= text_field_tag :school_search, params[:school_search], class: "govuk-input" %>
-      </div>
+    <% if @schools.blank? %>
 
-      <div class="govuk-form-group">
-        <%= submit_tag "Search", class: "govuk-button" %>
-      </div>
-    <% end %>
+      <span id="school-search-hint" class="govuk-hint">
+        Search for the school name.
+      </span>
+      <%= form_tag(claim_path("claim-school"), method: :get) do %>
+        <div class="govuk-form-group">
+          <%= label_tag :school_search, "School name", class: "govuk-label" %>
+          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input" %>
+        </div>
+        <div class="govuk-form-group">
+          <%= submit_tag "Search", class: "govuk-button" %>
+        </div>
+      <% end %>
 
-    <% if @schools.present? %>
-      <ul>
-        <% @schools.each do |school| %>
-          <li><%= school.name %></li>
-        <% end %>
-      </ul>
+    <% else %>
+
+      <span id="school-search-result-hint" class="govuk-hint">
+        Select your school from the search results.
+      </span>
+      <%= form_for current_claim, url: claim_path do |form| %>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
+            <div class="govuk-radios">
+              <%= form.collection_radio_buttons :claim_school_id, @schools, :id, :name do |b| %>
+                <div class="govuk-radios__item">
+                  <%= b.radio_button( class: "govuk-radios__input") %>
+                  <%= b.label class: "govuk-label govuk-radios__label"  %>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
+        </div>
+        <%= form.submit "Continue", class: "govuk-button" %>
+        <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+
     <% end %>
   </div>
 </div>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -28,6 +28,8 @@
         Select your school from the search results.
       </span>
       <%= form_for current_claim, url: claim_path do |form| %>
+        <%= hidden_field_tag :school_search, params[:school_search] %>
+
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
             <div class="govuk-radios">

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -9,9 +9,16 @@
 
     <% if @schools.blank? %>
 
-      <span id="school-search-hint" class="govuk-hint">
-        Search for the school name, use at least four characters.
-      </span>
+      <% if params[:school_search].present? && current_claim.errors.empty? %>
+        <p class="govuk-body">
+          <strong>No results match that search term. Try again.</strong>
+        </p>
+      <% else %>
+        <span id="school-search-hint" class="govuk-hint">
+          Search for the school name, use at least four characters.
+        </span>
+      <% end %>
+
       <%= form_tag(claim_path("claim-school"), method: :get) do %>
         <div class="govuk-form-group">
           <%= label_tag :school_search, "School name", class: "govuk-label" %>

--- a/app/views/claims/claim_school.html.erb
+++ b/app/views/claims/claim_school.html.erb
@@ -1,5 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
     <h1 class="govuk-heading-xl">
       Which school were you employed at between 6 April XXXX and 5 April XXXX?
     </h1>
@@ -7,7 +10,7 @@
     <% if @schools.blank? %>
 
       <span id="school-search-hint" class="govuk-hint">
-        Search for the school name.
+        Search for the school name, use at least four characters.
       </span>
       <%= form_tag(claim_path("claim-school"), method: :get) do %>
         <div class="govuk-form-group">

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Are you still employed to teach at a school in the UK?
+      </h1>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get "start/index"
   root "claims#new"
 
-  constraints slug: /qts-year|claim-school/ do
+  constraints slug: /qts-year|claim-school|still-teaching/ do
     resources :claims, only: [:new, :create, :show, :update], param: :slug
   end
 end

--- a/db/migrate/20190502093523_add_school_ref_to_tslr_claim.rb
+++ b/db/migrate/20190502093523_add_school_ref_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddSchoolRefToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tslr_claims, :claim_school, type: :uuid, foreign_key: {to_table: :schools}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_16_104000) do
+ActiveRecord::Schema.define(version: 2019_05_02_093523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -44,6 +44,9 @@ ActiveRecord::Schema.define(version: 2019_04_16_104000) do
     t.string "qts_award_year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "claim_school_id"
+    t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
   end
 
+  add_foreign_key "tslr_claims", "schools", column: "claim_school_id"
 end

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -29,4 +29,33 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
     expect(page).to have_text("Are you still employed to teach at a school in the UK")
   end
+
+  scenario "searches again to find school" do
+    visit root_path
+
+    click_on "Agree and continue"
+
+    claim = TslrClaim.order(:created_at).last
+
+    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
+    click_on "Continue"
+
+    expect(claim.reload.qts_award_year).to eql("2014-2015")
+    expect(page).to have_text("Which school were you employed at between")
+
+    fill_in "School name", with: "hamp"
+    click_on "Search"
+
+    click_on "Search again"
+
+    fill_in "School name", with: "penistone"
+    click_on "Search"
+
+    choose "Penistone Grammar School"
+    click_on "Continue"
+
+    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
+    expect(page).to have_text("Are you still employed to teach at a school in the UK")
+  end
 end

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.feature "Searching for school during Teacher Student Loan Repayments claims" do
+  scenario "doesn't select a school from the search results the first time around" do
+    visit root_path
+
+    click_on "Agree and continue"
+
+    claim = TslrClaim.order(:created_at).last
+
+    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
+    click_on "Continue"
+
+    expect(claim.reload.qts_award_year).to eql("2014-2015")
+    expect(page).to have_text("Which school were you employed at between")
+
+    fill_in "School name", with: "Penistone"
+    click_on "Search"
+
+    click_on "Continue"
+
+    expect(page).to have_text("There is a problem")
+    expect(page).to have_text("Select a school from the list")
+
+    choose "Penistone Grammar School"
+    click_on "Continue"
+
+    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
+    expect(page).to have_text("Are you still employed to teach at a school in the UK")
+  end
+end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -18,7 +18,11 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     fill_in "School name", with: "Penistone"
     click_on "Search"
 
-    expect(page).to have_text("Penistone Grammer School")
+    choose "Penistone Grammar School"
+    click_on "Continue"
+
+    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
+    expect(page).to have_text("Are you still employed to teach at a school in the UK")
   end
 
   scenario "Teacher cannot go to mid-claim page before starting a claim" do

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -14,6 +14,11 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.qts_award_year).to eql("2014-2015")
     expect(page).to have_text("Which school were you employed at between")
+
+    fill_in "School name", with: "Penistone"
+    click_on "Search"
+
+    expect(page).to have_text("Penistone Grammer School")
   end
 
   scenario "Teacher cannot go to mid-claim page before starting a claim" do

--- a/spec/fixtures/schools.yml
+++ b/spec/fixtures/schools.yml
@@ -1,0 +1,13 @@
+penistone_grammar_school:
+  name: Penistone Grammar School
+  urn: 1234
+  phase: secondary
+  school_type_group: la_maintained
+  school_type: community_school
+
+hampstead_school:
+  name: Hampstead School
+  urn: 4567
+  phase: secondary
+  school_type_group: la_maintained
+  school_type: community_school

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe School, type: :model do
 
   describe ".search" do
     it "return schools matching the search term" do
-      expect(School.search("Penistone")).to match_array([schools(:penistone_grammer_school)])
+      expect(School.search("Penistone")).to match_array([schools(:penistone_grammar_school)])
     end
   end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -8,4 +8,10 @@ RSpec.describe School, type: :model do
   it { should validate_presence_of(:school_type_group) }
   it { should validate_presence_of(:school_type) }
   it { should validate_presence_of(:phase) }
+
+  describe ".search" do
+    it "return schools matching the search term" do
+      expect(School.search("Penistone")).to match_array([schools(:penistone_grammer_school)])
+    end
+  end
 end

--- a/spec/models/school_spec.rb
+++ b/spec/models/school_spec.rb
@@ -14,4 +14,28 @@ RSpec.describe School, type: :model do
       expect(School.search("Penistone")).to match_array([schools(:penistone_grammar_school)])
     end
   end
+
+  describe "#address" do
+    it "returns a formatted address string" do
+      school = School.new(
+        street: "10 The Street",
+        locality: "The locality",
+        town: "Town",
+        county: "County",
+        postcode: "PC1 4TE"
+      )
+      expect(school.address).to eql("10 The Street, The locality, Town, County, PC1 4TE")
+    end
+
+    it "returns a formatted address string when attributes are missing" do
+      school = School.new(
+        street: "10 The Street",
+        locality: "",
+        town: "Town",
+        county: "County",
+        postcode: "PC1 4TE"
+      )
+      expect(school.address).to eql("10 The Street, Town, County, PC1 4TE")
+    end
+  end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -13,4 +13,13 @@ RSpec.describe TslrClaim, type: :model do
       end
     end
   end
+
+  context "when saving in the “claim-school” validation context" do
+    let(:custom_validation_context) { :"claim-school" }
+
+    it "it validates the claim_school" do
+      expect(TslrClaim.new).not_to be_valid(custom_validation_context)
+      expect(TslrClaim.new(claim_school: schools(:penistone_grammar_school))).to be_valid(custom_validation_context)
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,6 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
   config.global_fixtures = :all
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,6 +34,8 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
+  config.global_fixtures = :all
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe "Claims", type: :request do
           expect(response.body).not_to include schools(:hampstead_school).name
           expect(response.body).to include "Continue"
         end
+
+        it "only returns results if the search term is more than three characters" do
+          get claim_path("claim-school"), params: {school_search: "Pen"}
+
+          expect(response.body).to include("There is a problem")
+          expect(response.body).to include("Search for the school name with a minimum of four characters")
+          expect(response.body).not_to include(schools(:penistone_grammar_school).name)
+        end
       end
     end
 

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe "Claims", type: :request do
         it "searchers for schools using the search term" do
           get claim_path("claim-school"), params: {school_search: "Penistone"}
 
-          expect(response.body).to include schools(:penistone_grammer_school).name
+          expect(response.body).to include schools(:penistone_grammar_school).name
           expect(response.body).not_to include schools(:hampstead_school).name
+          expect(response.body).to include "Continue"
         end
       end
     end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -76,6 +76,17 @@ RSpec.describe "Claims", type: :request do
 
         expect(response.body).to include("Select the academic year you were awarded qualified teacher status")
       end
+
+      context "having searched for a school but not selected a school from the results on the claim-school page" do
+        it "re-renders the school search results with an error message" do
+          put claim_path("claim-school"), params: {school_search: "peniston", tslr_claim: {claim_school_id: ""}}
+
+          expect(response).to be_successful
+          expect(response.body).to include("There is a problem")
+          expect(response.body).to include("Select a school from the list")
+          expect(response.body).to include(schools(:penistone_grammar_school).name)
+        end
+      end
     end
 
     context "when a claim hasn’t been started yet" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -31,6 +31,15 @@ RSpec.describe "Claims", type: :request do
         get claim_path("claim-school")
         expect(response.body).to include("Which school were you employed at")
       end
+
+      context "when searching for a school on the claim-school page" do
+        it "searchers for schools using the search term" do
+          get claim_path("claim-school"), params: {school_search: "Penistone"}
+
+          expect(response.body).to include schools(:penistone_grammer_school).name
+          expect(response.body).not_to include schools(:hampstead_school).name
+        end
+      end
     end
 
     context "when a claim hasn’t been started yet" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -48,6 +48,12 @@ RSpec.describe "Claims", type: :request do
           expect(response.body).to include("Search for the school name with a minimum of four characters")
           expect(response.body).not_to include(schools(:penistone_grammar_school).name)
         end
+
+        it "shows an appropriate message when there are no search results" do
+          get claim_path("claim-school"), params: {school_search: "crocodile"}
+
+          expect(response.body).to include("No results match that search term")
+        end
       end
     end
 


### PR DESCRIPTION
So that a teacher can locate a school easily we allow them to search by school name.

We limit the search string to 4 characters on more to limit the number of returned schools.  Once a list of possible schools is displayed the teacher selects their school from the list by choosing a radio button. 

The radio buttons are displayed with the school name and the school address to allow the teacher to distinguise between schools with similar or identical names.

If the teacher is unable to locate their desired school, they can restart the search process to try again.

Our ambition is to use a Javascript autocomplete to progressively enhance this feature, this PR does not include this work.

## Updated Gem
This PR includes a version change on the `dxw_govuk_frontend_rails` gem to introduce the new secondary button pattern that we now use.

Story card: 

https://trello.com/c/W9G3hkfy
## Screenshots

School search:
![Screenshot 2019-05-09 at 14 38 38](https://user-images.githubusercontent.com/480578/57457883-44538400-7268-11e9-8cf7-8bcf5330a472.png)

School search name length validation: 
![Screenshot 2019-05-09 at 14 38 45](https://user-images.githubusercontent.com/480578/57457896-4cabbf00-7268-11e9-9e32-7e9d821d980d.png)

School search selection:
![Screenshot 2019-05-09 at 14 38 50](https://user-images.githubusercontent.com/480578/57457911-57feea80-7268-11e9-8ce1-177f3d2d2258.png)

School search no selection:
![Screenshot 2019-05-09 at 14 40 33](https://user-images.githubusercontent.com/480578/57457941-6b11ba80-7268-11e9-9df4-f0a471c31a26.png)

School search no results:
![Screenshot 2019-05-09 at 14 39 09](https://user-images.githubusercontent.com/480578/57457979-7bc23080-7268-11e9-96e3-d5dc223c508f.png)
