### PR TITLE
Determine if a given school meets the TSLR eligibility criteria

### DIFF
--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -81,4 +81,8 @@ class School < ApplicationRecord
   def address
     [street, locality, town, county, postcode].reject(&:blank?).join(", ")
   end
+
+  def eligible_for_tslr?
+    Tslr::SchoolEligibility.new(self).check
+  end
 end

--- a/app/services/tslr/school_eligibility.rb
+++ b/app/services/tslr/school_eligibility.rb
@@ -1,0 +1,60 @@
+module Tslr
+  class SchoolEligibility
+    ELIGIBLE_PHASES = %w[secondary middle_deemed_secondary].freeze
+    STATE_FUNDED_TYPE_GROUPS = %w[colleges la_maintained special_schools academies free_schools].freeze
+    ELIGIBLE_LOCAL_AUTHORITY_CODES = [
+      370, # Barnsley
+      890, # Blackpool
+      867, # Bracknell Forest
+      380, # Bradford
+      873, # Cambridgeshire
+      831, # Derby
+      830, # Derbyshire
+      371, # Doncaster
+      876, # Halton
+      340, # Knowsley
+      821, # Luton
+      806, # Middlesbrough
+      926, # Norfolk
+      812, # North-east Lincolnshire
+      815, # North Yorkshire
+      928, # Northamptonshire
+      929, # Northumberland
+      353, # Oldham
+      874, # Peterborough
+      851, # Portsmouth
+      355, # Salford
+      343, # Sefton
+      342, # St Helens
+      861, # Stoke-on-Trent
+      935, # Suffolk
+    ].freeze
+
+    def initialize(school)
+      @school = school
+    end
+
+    def check
+      eligible_local_authority? && state_funded? && eligible_phase?
+    end
+
+    private
+
+    def eligible_local_authority?
+      ELIGIBLE_LOCAL_AUTHORITY_CODES.include?(@school.local_authority.code)
+    end
+
+    def state_funded?
+      STATE_FUNDED_TYPE_GROUPS.include?(@school.school_type_group) &&
+        !independent_special_school?
+    end
+
+    def eligible_phase?
+      ELIGIBLE_PHASES.include?(@school.phase)
+    end
+
+    def independent_special_school?
+      @school.school_type == "other_independent_special_school"
+    end
+  end
+end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -2,5 +2,15 @@ FactoryBot.define do
   factory :local_authority do
     sequence(:code)
     name { "York" }
+
+    trait :eligible do
+      code { 380 }
+      name { "Bradford" }
+    end
+
+    trait :ineligible do
+      code { 201 }
+      name { "City of London" }
+    end
   end
 end

--- a/spec/factories/schools.rb
+++ b/spec/factories/schools.rb
@@ -2,9 +2,9 @@ FactoryBot.define do
   factory :school do
     sequence(:urn)
     name { "Acme Secondary School" }
-    school_type { 10 }
-    school_type_group { 5 }
-    phase { 4 }
-    local_authority
+    school_type { :community_school }
+    school_type_group { :la_maintained }
+    phase { :secondary }
+    local_authority { build(:local_authority, :eligible) }
   end
 end

--- a/spec/services/tslr/school_eligibility_spec.rb
+++ b/spec/services/tslr/school_eligibility_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+RSpec.describe Tslr::SchoolEligibility do
+  describe "#check" do
+    subject { Tslr::SchoolEligibility.new(school).check }
+    let(:school) { build(:school, school_attributes.merge({local_authority: local_authority})) }
+
+    context "when it is in an eligible area" do
+      let(:local_authority) { build(:local_authority, :eligible) }
+
+      context "and it is an academy" do
+        let(:academy_school_attributes) { {school_type_group: :academies} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { academy_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { academy_school_attributes.merge({phase: :primary}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a free school" do
+        let(:free_school_attributes) { {school_type_group: :free_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { free_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { free_school_attributes.merge({phase: :middle_deemed_primary}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a college" do
+        let(:college_attributes) { {school_type_group: :colleges} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { college_attributes.merge({phase: :middle_deemed_secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { college_attributes.merge({phase: :sixteen_plus}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a LA maintained school" do
+        let(:la_maintained_attributes) { {school_type_group: :la_maintained} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { la_maintained_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { la_maintained_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is a special school" do
+        let(:special_school_attributes) { {school_type_group: :special_schools} }
+
+        context "and it has an education phase of secondary or middle deemed secondary" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :secondary}) }
+          it { is_expected.to be true }
+        end
+
+        context "and it has an education phase of nursery, primary, middle deemed primary, 16+ or all through" do
+          let(:school_attributes) { special_school_attributes.merge({phase: :nursery}) }
+          it { is_expected.to be false }
+        end
+
+        context "and it is a state funded special school" do
+          let(:school_attributes) { special_school_attributes.merge({school_type: :community_school})}
+          it { is_expected.to be true }
+        end
+
+        context "and it is an independent special school" do
+          let(:school_attributes) { special_school_attributes.merge({school_type: :other_independent_special_school})}
+          it { is_expected.to be false }
+        end
+      end
+
+      context "and it is not a state funded school" do
+        let(:school_attributes) { {school_type_group: :independent_schools} }
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when it is not in an eligible area" do
+      let(:local_authority) { build(:local_authority, :ineligible) }
+      let(:school_attributes) { {} }
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
To be eligible for TSLR payments a teacher must've taught in a school that meets the following criteria:

- State funded school in England
- Local Authority maintained secondary (including middle deemed secondary)
- Local Authority maintained or non-maintained special schools
- Secondary phase academy/free school
- In one of the 25 participating local authorities

Using the data from the Get Information About Schools database and after talking with the Financial Incentives policy team we can make these assertions about school eligibility:

- State funded school means any school that isn't independent, a university, a welsh school or 'Other'
- Local Authority maintained, Colleges, Academies and Free schools are only eligible if they have a phase of secondary or middle deemed secondary
- All special schools are eligible except independent special schools.
  Note: The only way to filter out independent special schools is with the 'school type' field (they will have a 'school type group' of 'special_schools')

We may also want to capture the date a school closed and add a check to see if the school closed before the year the teacher is claiming for, however this wasn't part of the official criteria so I haven't included it in this PR. This means that it will be possible for a teacher to select a school that otherwise would be eligible but closed last decade.