### PR TITLE
A teacher can say whether they are still employed at a school

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -28,9 +28,8 @@ class ClaimsController < ApplicationController
   private
 
   def next_slug
-    sequence = ["qts-year", "claim-school", "still-teaching", "subject-percentage"]
-    current_slug_index = sequence.index(params[:slug])
-    sequence[current_slug_index + 1]
+    current_slug_index = TslrClaim::PAGE_SEQUENCE.index(params[:slug])
+    TslrClaim::PAGE_SEQUENCE[current_slug_index + 1]
   end
 
   def perform_non_js_school_search

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -28,8 +28,8 @@ class ClaimsController < ApplicationController
   private
 
   def next_slug
-    current_slug_index = TslrClaim::PAGE_SEQUENCE.index(params[:slug])
-    TslrClaim::PAGE_SEQUENCE[current_slug_index + 1]
+    current_slug_index = current_claim.page_sequence.index(params[:slug])
+    current_claim.page_sequence[current_slug_index + 1]
   end
 
   def perform_non_js_school_search
@@ -41,7 +41,7 @@ class ClaimsController < ApplicationController
   end
 
   def claim_params
-    params.require(:tslr_claim).permit(:qts_award_year, :claim_school_id, :employment_status)
+    params.require(:tslr_claim).permit(:qts_award_year, :claim_school_id, :employment_status, :current_school_id)
   end
 
   def claim_page_template

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -19,19 +19,19 @@ class ClaimsController < ApplicationController
   def update
     current_claim.attributes = claim_params
     if current_claim.save(context: params[:slug].to_sym)
-      if params[:slug] == "qts-year"
-        redirect_to claim_path("claim-school")
-      elsif params[:slug] == "claim-school"
-        redirect_to claim_path("still-teaching")
-      elsif params[:slug] == "still-teaching"
-        redirect_to claim_path("subject-percentage")
-      end
+      redirect_to claim_path(next_slug)
     else
       show
     end
   end
 
   private
+
+  def next_slug
+    sequence = ["qts-year", "claim-school", "still-teaching", "subject-percentage"]
+    current_slug_index = sequence.index(params[:slug])
+    sequence[current_slug_index + 1]
+  end
 
   def perform_non_js_school_search
     if params[:school_search].length > 3

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -23,6 +23,8 @@ class ClaimsController < ApplicationController
         redirect_to claim_path("claim-school")
       elsif params[:slug] == "claim-school"
         redirect_to claim_path("still-teaching")
+      elsif params[:slug] == "still-teaching"
+        redirect_to claim_path("subject-percentage")
       end
     else
       show
@@ -40,7 +42,7 @@ class ClaimsController < ApplicationController
   end
 
   def claim_params
-    params.require(:tslr_claim).permit(:qts_award_year, :claim_school_id)
+    params.require(:tslr_claim).permit(:qts_award_year, :claim_school_id, :employment_status)
   end
 
   def claim_page_template

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -23,6 +23,7 @@ class TslrClaim < ApplicationRecord
   }, _prefix: :employed_at
 
   belongs_to :claim_school, optional: true, class_name: "School"
+  belongs_to :current_school, optional: true, class_name: "School"
 
   validates :claim_school,      on: :"claim-school", presence: {message: "Select a school from the list"}
   validates :qts_award_year,    on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -9,6 +9,12 @@ class TslrClaim < ApplicationRecord
     "2019-2020",
   ].freeze
 
+  enum employment_status: {
+    claim_school: 0,
+    different_school: 1,
+    no_school: 2,
+  }, _prefix: :employed_at
+
   belongs_to :claim_school, optional: true, class_name: "School"
   validates :claim_school, presence: {message: "Select a school from the list"}, on: :"claim-school"
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -30,11 +30,17 @@ class TslrClaim < ApplicationRecord
   validates :qts_award_year,    on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
   validates :employment_status, on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
 
+  before_save :update_current_school, if: :employment_status_changed?
+
   delegate :name, to: :claim_school, prefix: true, allow_nil: true
 
   def page_sequence
     PAGE_SEQUENCE.dup.tap do |sequence|
       sequence.delete("current-school") if employed_at_claim_school?
     end
+  end
+
+  def update_current_school
+    self.current_school = employed_at_claim_school? ? claim_school : nil
   end
 end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -3,6 +3,7 @@ class TslrClaim < ApplicationRecord
     "qts-year",
     "claim-school",
     "still-teaching",
+    "current-school",
     "subject-percentage",
   ].freeze
 
@@ -30,4 +31,10 @@ class TslrClaim < ApplicationRecord
   validates :employment_status, on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
 
   delegate :name, to: :claim_school, prefix: true, allow_nil: true
+
+  def page_sequence
+    PAGE_SEQUENCE.dup.tap do |sequence|
+      sequence.delete("current-school") if employed_at_claim_school?
+    end
+  end
 end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -17,6 +17,9 @@ class TslrClaim < ApplicationRecord
 
   belongs_to :claim_school, optional: true, class_name: "School"
 
-  validates :claim_school,   on: :"claim-school", presence: {message: "Select a school from the list"}
-  validates :qts_award_year, on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
+  validates :claim_school,      on: :"claim-school", presence: {message: "Select a school from the list"}
+  validates :qts_award_year,    on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
+  validates :employment_status, on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
+
+  delegate :name, to: :claim_school, prefix: true, allow_nil: true
 end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -16,7 +16,7 @@ class TslrClaim < ApplicationRecord
   }, _prefix: :employed_at
 
   belongs_to :claim_school, optional: true, class_name: "School"
-  validates :claim_school, presence: {message: "Select a school from the list"}, on: :"claim-school"
 
-  validates :qts_award_year, inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}, on: :"qts-year"
+  validates :claim_school,   on: :"claim-school", presence: {message: "Select a school from the list"}
+  validates :qts_award_year, on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
 end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -1,4 +1,11 @@
 class TslrClaim < ApplicationRecord
+  PAGE_SEQUENCE = [
+    "qts-year",
+    "claim-school",
+    "still-teaching",
+    "subject-percentage",
+  ].freeze
+
   VALID_QTS_YEARS = [
     "2013-2014",
     "2014-2015",

--- a/app/views/claims/current_school.html.erb
+++ b/app/views/claims/current_school.html.erb
@@ -1,0 +1,59 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
+    <h1 class="govuk-heading-xl">
+      Which school are you currently employed at?
+    </h1>
+
+    <% if @schools.blank? %>
+
+      <% if params[:school_search].present? && current_claim.errors.empty? %>
+        <p class="govuk-body">
+          <strong>No results match that search term. Try again.</strong>
+        </p>
+      <% else %>
+        <span id="school-search-hint" class="govuk-hint">
+          Search for the school name, use at least four characters.
+        </span>
+      <% end %>
+
+      <%= form_tag(claim_path("current-school"), method: :get) do %>
+        <div class="govuk-form-group">
+          <%= label_tag :school_search, "School name", class: "govuk-label" %>
+          <%= text_field_tag :school_search, params[:school_search], class: "govuk-input" %>
+        </div>
+        <div class="govuk-form-group">
+          <%= submit_tag "Search", class: "govuk-button" %>
+        </div>
+      <% end %>
+
+    <% else %>
+
+      <span id="school-search-result-hint" class="govuk-hint">
+        Select your school from the search results.
+      </span>
+      <%= form_for current_claim, url: claim_path do |form| %>
+        <%= hidden_field_tag :school_search, params[:school_search] %>
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset" aria-describedby="school-search-result-hint">
+            <div class="govuk-radios">
+              <%= form.collection_radio_buttons :current_school_id, @schools, :id, :name do |b| %>
+                <div class="govuk-radios__item">
+                  <%= b.radio_button class: "govuk-radios__input" %>
+                  <%= b.label class: "govuk-label govuk-radios__label govuk-label--s" %>
+                  <span class="govuk-hint govuk-radios__hint"><%= b.object.address %></span>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
+        </div>
+        <%= form.submit "Continue", class: "govuk-button" %>
+        <%= link_to "Search again", claim_path, class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        Are you still employed to teach at a school in the UK?
-      </h1>
+    <h1 class="govuk-heading-xl">
+      Are you still employed to teach at a school in England?
+    </h1>
   </div>
 </div>

--- a/app/views/claims/still_teaching.html.erb
+++ b/app/views/claims/still_teaching.html.erb
@@ -1,7 +1,30 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      Are you still employed to teach at a school in England?
-    </h1>
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+            <h1 class="govuk-fieldset__heading">Are you still employed to teach at a school in England?</h1>
+          </legend>
+          <div class="govuk-radios">
+            <%= form.hidden_field :employment_status %>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:employment_status, :claim_school, class: "govuk-radios__input") %>
+              <%= form.label :employment_status_claim_school, "Yes, at #{current_claim.claim_school_name}", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:employment_status, :different_school, class: "govuk-radios__input") %>
+              <%= form.label :employment_status_different_school, "Yes, at another school", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(:employment_status, :no_school, class: "govuk-radios__input") %>
+              <%= form.label :employment_status_no_school, "No", class: "govuk-label govuk-radios__label" %>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+      <%= form.submit "Continue", class: "govuk-button" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/claims/subject_percentage.html.erb
+++ b/app/views/claims/subject_percentage.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Did you teach some subjects 50% of your time?
+    </h1>
+
+    <p class="govuk-body">
+      Coming soon&hellip;
+    </p>
+  </div>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,5 +51,6 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.bullet_logger = true
     Bullet.raise = true
+    Bullet.add_whitelist type: :unused_eager_loading, class_name: "TslrClaim", association: :current_school
   end
 end

--- a/config/initializers/customise_form_errors.rb
+++ b/config/initializers/customise_form_errors.rb
@@ -1,0 +1,3 @@
+ActionView::Base.field_error_proc = proc do |html_tag, instance|
+  html_tag
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "claims#new"
 
-  constraints slug: /qts-year|claim-school|still-teaching/ do
+  constraints slug: /qts-year|claim-school|still-teaching|subject-percentage/ do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root "claims#new"
 
-  constraints slug: /qts-year|claim-school|still-teaching|subject-percentage/ do
+  constraints slug: %r{#{TslrClaim::PAGE_SEQUENCE.join("|")}} do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
 end

--- a/db/migrate/20190509150211_add_employment_status_to_tslr_claim.rb
+++ b/db/migrate/20190509150211_add_employment_status_to_tslr_claim.rb
@@ -1,0 +1,6 @@
+class AddEmploymentStatusToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :employment_status, :integer
+    add_index :tslr_claims, :employment_status
+  end
+end

--- a/db/migrate/20190513135311_add_current_school_id_to_tslr_claims.rb
+++ b/db/migrate/20190513135311_add_current_school_id_to_tslr_claims.rb
@@ -1,0 +1,5 @@
+class AddCurrentSchoolIdToTslrClaims < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :tslr_claims, :current_school, type: :uuid, foreign_key: {to_table: :schools}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_02_093523) do
+ActiveRecord::Schema.define(version: 2019_05_09_150211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -45,7 +45,9 @@ ActiveRecord::Schema.define(version: 2019_05_02_093523) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.uuid "claim_school_id"
+    t.integer "employment_status"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
+    t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"
   end
 
   add_foreign_key "tslr_claims", "schools", column: "claim_school_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_09_150211) do
+ActiveRecord::Schema.define(version: 2019_05_13_135311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -46,9 +46,12 @@ ActiveRecord::Schema.define(version: 2019_05_09_150211) do
     t.datetime "updated_at", null: false
     t.uuid "claim_school_id"
     t.integer "employment_status"
+    t.uuid "current_school_id"
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
+    t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"
   end
 
   add_foreign_key "tslr_claims", "schools", column: "claim_school_id"
+  add_foreign_key "tslr_claims", "schools", column: "current_school_id"
 end

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in the UK")
+    expect(page).to have_text("Are you still employed to teach at a school in England")
   end
 
   scenario "searches again to find school" do
@@ -56,6 +56,6 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
     click_on "Continue"
 
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in the UK")
+    expect(page).to have_text("Are you still employed to teach at a school in England")
   end
 end

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -23,6 +23,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
     expect(page).to have_text("Are you still employed to teach at a school in England")
+
+    choose "Yes, at Penistone Grammar School"
+    click_on "Continue"
+
+    expect(claim.reload.employment_status).to eql("claim_school")
+    expect(page).to have_text("Did you teach")
   end
 
   scenario "Teacher cannot go to mid-claim page before starting a claim" do

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     click_on "Continue"
 
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in the UK")
+    expect(page).to have_text("Are you still employed to teach at a school in England")
   end
 
   scenario "Teacher cannot go to mid-claim page before starting a claim" do

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -31,6 +31,44 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text("Did you teach")
   end
 
+  scenario "Teacher now works for a different school" do
+    visit root_path
+
+    click_on "Agree and continue"
+
+    claim = TslrClaim.order(:created_at).last
+
+    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
+    click_on "Continue"
+
+    expect(claim.reload.qts_award_year).to eql("2014-2015")
+    expect(page).to have_text("Which school were you employed at between")
+
+    fill_in "School name", with: "Penistone"
+    click_on "Search"
+
+    choose "Penistone Grammar School"
+    click_on "Continue"
+
+    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
+    expect(page).to have_text("Are you still employed to teach at a school in England")
+
+    choose "Yes, at another school"
+    click_on "Continue"
+
+    expect(claim.reload.employment_status).to eql("different_school")
+
+    fill_in "School name", with: "Hampstead"
+    click_on "Search"
+
+    choose "Hampstead School"
+    click_on "Continue"
+
+    expect(claim.reload.current_school).to eql schools(:hampstead_school)
+    expect(page).to have_text("Did you teach")
+  end
+
   scenario "Teacher cannot go to mid-claim page before starting a claim" do
     visit claim_path("qts-year")
     expect(page).to have_current_path(root_path)

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     click_on "Continue"
 
     expect(claim.reload.employment_status).to eql("claim_school")
+    expect(claim.current_school).to eql(schools(:penistone_grammar_school))
     expect(page).to have_text("Did you teach")
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -58,4 +58,21 @@ RSpec.describe TslrClaim, type: :model do
       expect(TslrClaim.new.claim_school_name).to be_nil
     end
   end
+
+  describe "#page_sequence" do
+    let(:tslr_claim) { TslrClaim.new }
+    it "returns all the pages in the sequence" do
+      expect(tslr_claim.page_sequence).to eq TslrClaim::PAGE_SEQUENCE
+    end
+
+    context "when the claimant still works at the school they are claiming against" do
+      let(:tslr_claim) do
+        TslrClaim.new(claim_school: schools(:penistone_grammar_school), employment_status: :claim_school)
+      end
+
+      it "excludes the “current-school” page from the sequence" do
+        expect(tslr_claim.page_sequence).not_to include("current-school")
+      end
+    end
+  end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe TslrClaim, type: :model do
+  it { should belong_to(:claim_school).optional }
+  it { should belong_to(:current_school).optional }
+
   context "when saving in the “qts-year” validation context" do
     let(:custom_validation_context) { :"qts-year" }
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -22,4 +22,19 @@ RSpec.describe TslrClaim, type: :model do
       expect(TslrClaim.new(claim_school: schools(:penistone_grammar_school))).to be_valid(custom_validation_context)
     end
   end
+
+  describe "#employment_status" do
+    it "provides an enum that captures the claiment’s employment status" do
+      claim = TslrClaim.new
+
+      claim.employment_status = :claim_school
+      expect(claim.employed_at_claim_school?).to eq true
+      expect(claim.employed_at_different_school?).to eq false
+      expect(claim.employed_at_no_school?).to eq false
+    end
+
+    it "rejects invalid employment statuses" do
+      expect { TslrClaim.new(employment_status: :nonsense) }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “still-teaching” validation context" do
+    it "validates employment_status has been provided" do
+      expect(TslrClaim.new).not_to be_valid(:"still-teaching")
+      expect(TslrClaim.new(employment_status: :claim_school)).to be_valid(:"still-teaching")
+    end
+  end
+
   describe "#employment_status" do
     it "provides an enum that captures the claiment’s employment status" do
       claim = TslrClaim.new
@@ -35,6 +42,17 @@ RSpec.describe TslrClaim, type: :model do
 
     it "rejects invalid employment statuses" do
       expect { TslrClaim.new(employment_status: :nonsense) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#claim_school_name" do
+    it "returns the name of the claim school" do
+      claim = TslrClaim.new(claim_school: schools(:penistone_grammar_school))
+      expect(claim.claim_school_name).to eq schools(:penistone_grammar_school).name
+    end
+
+    it "does not error if the claim school is not set" do
+      expect(TslrClaim.new.claim_school_name).to be_nil
     end
   end
 end

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -46,6 +46,36 @@ RSpec.describe TslrClaim, type: :model do
     it "rejects invalid employment statuses" do
       expect { TslrClaim.new(employment_status: :nonsense) }.to raise_error(ArgumentError)
     end
+
+    context "when set to :claim_school" do
+      it "automatically sets current_school to the claim_school" do
+        claim = TslrClaim.new(claim_school: schools(:penistone_grammar_school))
+        claim.employment_status = :claim_school
+        claim.save!
+
+        expect(claim.current_school).to eql(schools(:penistone_grammar_school))
+      end
+    end
+
+    context "when changed to :different_school" do
+      it "automatically resets current_school to nil" do
+        claim = TslrClaim.new(claim_school: schools(:penistone_grammar_school), current_school: schools(:penistone_grammar_school), employment_status: :claim_school)
+        claim.employment_status = :different_school
+        claim.save!
+
+        expect(claim.current_school).to be_nil
+      end
+    end
+
+    context "when value is :different_school" do
+      it "does not automatically reset current_school if employment_status hasn’t changed" do
+        claim = TslrClaim.create!(claim_school: schools(:penistone_grammar_school), employment_status: :different_school)
+        claim.current_school = schools(:hampstead_school)
+        claim.save!
+
+        expect(claim.current_school).to eql(schools(:hampstead_school))
+      end
+    end
   end
 
   describe "#claim_school_name" do


### PR DESCRIPTION
So a teacher can confirm their eligibility, we need to know they are still teaching and we would like to know at which shcool.

We've added a postgres enum to the database to store the teachers 'employment status', this has meant switching schema formats to sql rather than the usual rb.

We decided to duplicate the still teaching question view for now to keep our approach as simple as possible and our views clearly named, we like the idea of one view per question.

The sequence of pages shown to a teacher is stored in the model and we've laid the groundwork to enable us to skip pages based on certain criteria.

If a teacher is still teaching at the same school as they are claiming for, we still wanted to store that school in the `current_school` association, we've done this in the model with a before_save callback, this led to a problem with Bullet that we've not resolved yet, so the `unused_eager_loading` is now disabled on the current school association in the testing environment, see 170450385ab2582e896d720bf9e037ae6054c951

This work does not include checking an eligibility, this will come later.

## I'm concerned about
- We should look at the Bullet issue and confirm we are happy to ignore the error it it raising.
- Whilst I am confident that disabling the 'field_with_error' css class is the right call now, I'm worried about impact elsewhere or that we forget it's been switched off, perhaps makeing a card in the backlog is a good idea?

## Screenshots
Question:
![Screenshot_2019-05-14 Teachers claim back student loan repayments](https://user-images.githubusercontent.com/480578/57696456-b4874e80-7648-11e9-917e-bdab09770861.png)

Searching for current school:
![Screenshot_2019-05-14 Teachers claim back student loan repayments(2)](https://user-images.githubusercontent.com/480578/57696506-cd8fff80-7648-11e9-8105-c44e5ec91343.png)
![Screenshot_2019-05-14 Teachers claim back student loan repayments(3)](https://user-images.githubusercontent.com/480578/57696522-cff25980-7648-11e9-8c16-238f562e118b.png)

Stubbed next question:
![Screenshot_2019-05-14 Teachers claim back student loan repayments(1)](https://user-images.githubusercontent.com/480578/57696550-dd0f4880-7648-11e9-9959-54411571b1b7.png)

