### PR TITLE
Claim ineligibility for ineligible claim school and no longer teaching

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -19,7 +19,7 @@ class ClaimsController < ApplicationController
   def update
     current_claim.attributes = claim_params
     if current_claim.save(context: params[:slug].to_sym)
-      redirect_to claim_path(next_slug)
+      redirect_to next_claim_path
     else
       show
     end
@@ -29,6 +29,14 @@ class ClaimsController < ApplicationController
   end
 
   private
+
+  def next_claim_path
+    if current_claim.ineligible?
+      ineligible_claim_path
+    else
+      claim_path(next_slug)
+    end
+  end
 
   def next_slug
     current_slug_index = current_claim.page_sequence.index(params[:slug])

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -1,5 +1,5 @@
 class ClaimsController < ApplicationController
-  before_action :send_unstarted_claiments_to_the_start, only: [:show, :update]
+  before_action :send_unstarted_claiments_to_the_start, only: [:show, :update, :ineligible]
 
   def new
   end
@@ -23,6 +23,9 @@ class ClaimsController < ApplicationController
     else
       show
     end
+  end
+
+  def ineligible
   end
 
   private

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -5,4 +5,8 @@ module ClaimsHelper
       ["September 1 #{start_year} - August 31 #{end_year}", academic_years]
     end
   end
+
+  def tslr_guidance_url
+    "https://www.gov.uk/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools"
+  end
 end

--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -6,6 +6,14 @@ module ClaimsHelper
     end
   end
 
+  def tslr_claim_ineligibility_reason(claim)
+    case claim.ineligibility_reason
+    when :ineligible_claim_school then "#{claim.claim_school_name} is not an eligible school."
+    when :employed_at_no_school then "You must be still working as a teacher to be eligible."
+    else "You can only apply for this payment if you meet the eligibility criteria."
+    end
+  end
+
   def tslr_guidance_url
     "https://www.gov.uk/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools"
   end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -40,6 +40,8 @@ class TslrClaim < ApplicationRecord
     end
   end
 
+  private
+
   def update_current_school
     self.current_school = employed_at_claim_school? ? claim_school : nil
   end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -41,10 +41,14 @@ class TslrClaim < ApplicationRecord
   end
 
   def ineligible?
-    claim_school.present? && !claim_school.eligible_for_tslr?
+    ineligible_claim_school? || employed_at_no_school?
   end
 
   private
+
+  def ineligible_claim_school?
+    claim_school.present? && !claim_school.eligible_for_tslr?
+  end
 
   def update_current_school
     self.current_school = employed_at_claim_school? ? claim_school : nil

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -40,6 +40,10 @@ class TslrClaim < ApplicationRecord
     end
   end
 
+  def ineligible?
+    claim_school.present? && !claim_school.eligible_for_tslr?
+  end
+
   private
 
   def update_current_school

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -44,6 +44,10 @@ class TslrClaim < ApplicationRecord
     ineligible_claim_school? || employed_at_no_school?
   end
 
+  def ineligibility_reason
+    [:ineligible_claim_school, :employed_at_no_school].find { |eligibility_check| send("#{eligibility_check}?") }
+  end
+
   private
 
   def ineligible_claim_school?

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-body">
-      You can only apply for this payment if you meet the eligibility criteria.
+      <%= tslr_claim_ineligibility_reason(current_claim) %>
     </p>
 
     <p class="govuk-body">

--- a/app/views/claims/ineligible.html.erb
+++ b/app/views/claims/ineligible.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      You’re not eligible to for this service
+    </h1>
+
+    <p class="govuk-body">
+      You can only apply for this payment if you meet the eligibility criteria.
+    </p>
+
+    <p class="govuk-body">
+      You can find more information on the <%= link_to "guidance for this service", tslr_guidance_url %>.
+    </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   constraints slug: %r{#{TslrClaim::PAGE_SEQUENCE.join("|")}} do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
+  get "/claim/ineligible", to: "claims#ineligible", as: :ineligible_claim
 end

--- a/spec/features/school_search_spec.rb
+++ b/spec/features/school_search_spec.rb
@@ -2,18 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Searching for school during Teacher Student Loan Repayments claims" do
   scenario "doesn't select a school from the search results the first time around" do
-    visit root_path
-
-    click_on "Agree and continue"
-
-    claim = TslrClaim.order(:created_at).last
-
-    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
-    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
-    click_on "Continue"
-
-    expect(claim.reload.qts_award_year).to eql("2014-2015")
-    expect(page).to have_text("Which school were you employed at between")
+    claim = start_tslr_claim
+    choose_qts_year
 
     fill_in "School name", with: "Penistone"
     click_on "Search"
@@ -31,18 +21,8 @@ RSpec.feature "Searching for school during Teacher Student Loan Repayments claim
   end
 
   scenario "searches again to find school" do
-    visit root_path
-
-    click_on "Agree and continue"
-
-    claim = TslrClaim.order(:created_at).last
-
-    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
-    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
-    click_on "Continue"
-
-    expect(claim.reload.qts_award_year).to eql("2014-2015")
-    expect(page).to have_text("Which school were you employed at between")
+    claim = start_tslr_claim
+    choose_qts_year
 
     fill_in "School name", with: "hamp"
     click_on "Search"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -94,6 +94,36 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text("You’re not eligible")
   end
 
+  scenario "no longer teaching" do
+    visit root_path
+
+    click_on "Agree and continue"
+
+    claim = TslrClaim.order(:created_at).last
+
+    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
+    click_on "Continue"
+
+    expect(claim.reload.qts_award_year).to eql("2014-2015")
+    expect(page).to have_text("Which school were you employed at between")
+
+    fill_in "School name", with: "Penistone"
+    click_on "Search"
+
+    choose "Penistone Grammar School"
+    click_on "Continue"
+
+    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
+    expect(page).to have_text("Are you still employed to teach at a school in England")
+
+    choose "No"
+    click_on "Continue"
+
+    expect(claim.reload.employment_status).to eq("no_school")
+    expect(page).to have_text("You’re not eligible")
+  end
+
   scenario "Teacher cannot go to mid-claim page before starting a claim" do
     visit claim_path("qts-year")
     expect(page).to have_current_path(root_path)

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -2,25 +2,14 @@ require "rails_helper"
 
 RSpec.feature "Teacher Student Loan Repayments claims" do
   scenario "Teacher claims back student loan repayments" do
-    visit root_path
-
-    click_on "Agree and continue"
-
-    claim = TslrClaim.order(:created_at).last
-
+    claim = start_tslr_claim
     expect(page).to have_text("Which academic year were you awarded qualified teacher status")
-    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
-    click_on "Continue"
 
+    choose_qts_year
     expect(claim.reload.qts_award_year).to eql("2014-2015")
     expect(page).to have_text("Which school were you employed at between")
 
-    fill_in "School name", with: "Penistone"
-    click_on "Search"
-
-    choose "Penistone Grammar School"
-    click_on "Continue"
-
+    choose_school schools(:penistone_grammar_school)
     expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
     expect(page).to have_text("Are you still employed to teach at a school in England")
 
@@ -33,27 +22,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   end
 
   scenario "Teacher now works for a different school" do
-    visit root_path
-
-    click_on "Agree and continue"
-
-    claim = TslrClaim.order(:created_at).last
-
-    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
-    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
-    click_on "Continue"
-
-    expect(claim.reload.qts_award_year).to eql("2014-2015")
-    expect(page).to have_text("Which school were you employed at between")
-
-    fill_in "School name", with: "Penistone"
-    click_on "Search"
-
-    choose "Penistone Grammar School"
-    click_on "Continue"
-
-    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in England")
+    claim = start_tslr_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
 
     choose "Yes, at another school"
     click_on "Continue"
@@ -71,24 +42,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   end
 
   scenario "chooses an ineligible school" do
-    visit root_path
-
-    click_on "Agree and continue"
-
-    claim = TslrClaim.order(:created_at).last
-
-    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
-    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
-    click_on "Continue"
-
-    expect(claim.reload.qts_award_year).to eql("2014-2015")
-    expect(page).to have_text("Which school were you employed at between")
-
-    fill_in "School name", with: "Hampstead"
-    click_on "Search"
-
-    choose "Hampstead School"
-    click_on "Continue"
+    claim = start_tslr_claim
+    choose_qts_year
+    choose_school schools(:hampstead_school)
 
     expect(claim.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
@@ -96,27 +52,9 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
   end
 
   scenario "no longer teaching" do
-    visit root_path
-
-    click_on "Agree and continue"
-
-    claim = TslrClaim.order(:created_at).last
-
-    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
-    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
-    click_on "Continue"
-
-    expect(claim.reload.qts_award_year).to eql("2014-2015")
-    expect(page).to have_text("Which school were you employed at between")
-
-    fill_in "School name", with: "Penistone"
-    click_on "Search"
-
-    choose "Penistone Grammar School"
-    click_on "Continue"
-
-    expect(claim.reload.claim_school).to eql schools(:penistone_grammar_school)
-    expect(page).to have_text("Are you still employed to teach at a school in England")
+    claim = start_tslr_claim
+    choose_qts_year
+    choose_school schools(:penistone_grammar_school)
 
     choose "No"
     click_on "Continue"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -70,6 +70,30 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
     expect(page).to have_text("Did you teach")
   end
 
+  scenario "chooses an ineligible school" do
+    visit root_path
+
+    click_on "Agree and continue"
+
+    claim = TslrClaim.order(:created_at).last
+
+    expect(page).to have_text("Which academic year were you awarded qualified teacher status")
+    select "September 1 2014 - August 31 2015", from: :tslr_claim_qts_award_year
+    click_on "Continue"
+
+    expect(claim.reload.qts_award_year).to eql("2014-2015")
+    expect(page).to have_text("Which school were you employed at between")
+
+    fill_in "School name", with: "Hampstead"
+    click_on "Search"
+
+    choose "Hampstead School"
+    click_on "Continue"
+
+    expect(claim.reload.claim_school).to eq schools(:hampstead_school)
+    expect(page).to have_text("You’re not eligible")
+  end
+
   scenario "Teacher cannot go to mid-claim page before starting a claim" do
     visit claim_path("qts-year")
     expect(page).to have_current_path(root_path)

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -92,6 +92,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.claim_school).to eq schools(:hampstead_school)
     expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("Hampstead School is not an eligible school")
   end
 
   scenario "no longer teaching" do
@@ -122,6 +123,7 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.employment_status).to eq("no_school")
     expect(page).to have_text("You’re not eligible")
+    expect(page).to have_text("You must be still working as a teacher to be eligible")
   end
 
   scenario "Teacher cannot go to mid-claim page before starting a claim" do

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -33,6 +33,25 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  describe "#ineligible?" do
+    subject { TslrClaim.new(claim_school: claim_school).ineligible? }
+
+    context "with no claim_school" do
+      let(:claim_school) { nil }
+      it { is_expected.to be false }
+    end
+
+    context "with an eligible claim school" do
+      let(:claim_school) { schools(:penistone_grammar_school) }
+      it { is_expected.to be false }
+    end
+
+    context "with an ineligible claim_school" do
+      let(:claim_school) { schools(:hampstead_school) }
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#employment_status" do
     it "provides an enum that captures the claiment’s employment status" do
       claim = TslrClaim.new

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -57,6 +57,25 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  describe "#ineligibility_reason" do
+    subject { TslrClaim.new(claim_attributes).ineligibility_reason }
+
+    context "with an ineligible claim_school" do
+      let(:claim_attributes) { {claim_school: schools(:hampstead_school)} }
+      it { is_expected.to eql :ineligible_claim_school }
+    end
+
+    context "when no longer teaching" do
+      let(:claim_attributes) { {employment_status: :no_school} }
+      it { is_expected.to eql :employed_at_no_school }
+    end
+
+    context "when not ineligible" do
+      let(:claim_attributes) { {} }
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe "#employment_status" do
     it "provides an enum that captures the claiment’s employment status" do
       claim = TslrClaim.new

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -34,20 +34,25 @@ RSpec.describe TslrClaim, type: :model do
   end
 
   describe "#ineligible?" do
-    subject { TslrClaim.new(claim_school: claim_school).ineligible? }
+    subject { TslrClaim.new(claim_attributes).ineligible? }
 
     context "with no claim_school" do
-      let(:claim_school) { nil }
+      let(:claim_attributes) { {claim_school: nil} }
       it { is_expected.to be false }
     end
 
     context "with an eligible claim school" do
-      let(:claim_school) { schools(:penistone_grammar_school) }
+      let(:claim_attributes) { {claim_school: schools(:penistone_grammar_school)} }
       it { is_expected.to be false }
     end
 
     context "with an ineligible claim_school" do
-      let(:claim_school) { schools(:hampstead_school) }
+      let(:claim_attributes) { {claim_school: schools(:hampstead_school)} }
+      it { is_expected.to be true }
+    end
+
+    context "when no longer teaching" do
+      let(:claim_attributes) { {employment_status: :no_school} }
       it { is_expected.to be true }
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FeatureHelpers, type: :feature
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe "Claims", type: :request do
         get ineligible_claim_path
         expect(response.body).to include("You’re not eligible")
       end
+
+      it "tailors the message to the claim" do
+        TslrClaim.order(:created_at).last.update(employment_status: "no_school")
+
+        get ineligible_claim_path
+        expect(response.body).to include("You’re not eligible")
+        expect(response.body).to include("You must be still working as a teacher to be eligible")
+      end
     end
 
     context "when a claim hasn’t been started yet" do

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -63,6 +63,24 @@ RSpec.describe "Claims", type: :request do
     end
   end
 
+  describe "claim#ineligible request" do
+    context "when a claim is already in progress" do
+      before { post claims_path }
+
+      it "renders a static ineligibility page" do
+        get ineligible_claim_path
+        expect(response.body).to include("You’re not eligible")
+      end
+    end
+
+    context "when a claim hasn’t been started yet" do
+      it "redirects to the start page" do
+        get ineligible_claim_path
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
+
   describe "claims#update request" do
     context "when a claim is already in progress" do
       let(:in_progress_claim) { TslrClaim.order(:created_at).last }

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -109,6 +109,14 @@ RSpec.describe "Claims", type: :request do
           expect(response.body).to include(schools(:penistone_grammar_school).name)
         end
       end
+
+      context "when the update makes the claim ineligible" do
+        it "redirects to the “ineligible” page" do
+          put claim_path("claim-school"), params: {tslr_claim: {claim_school_id: schools(:hampstead_school).to_param}}
+
+          expect(response).to redirect_to(ineligible_claim_path)
+        end
+      end
     end
 
     context "when a claim hasn’t been started yet" do

--- a/spec/support/feature_helpers.rb
+++ b/spec/support/feature_helpers.rb
@@ -1,0 +1,20 @@
+module FeatureHelpers
+  def start_tslr_claim
+    visit root_path
+    click_on "Agree and continue"
+    TslrClaim.order(:created_at).last
+  end
+
+  def choose_qts_year(year = "September 1 2014 - August 31 2015")
+    select year, from: :tslr_claim_qts_award_year
+    click_on "Continue"
+  end
+
+  def choose_school(school)
+    fill_in "School name", with: school.name.split(" ").first
+    click_on "Search"
+
+    choose school.name
+    click_on "Continue"
+  end
+end


### PR DESCRIPTION
This adds a new "You’re not eligible to for this service" page to the claim process. A claimant that tries to claim against an ineligible school is shown this page. A claimant that says they are no longer teaching is shown this page. In both cases a custom reason is given for the ineligibility.

The final commit refactors the feature specs by extracting helpers for performing common steps in the claim process.

This delivers the following two stories:

- https://trello.com/c/plhfSljn/116-teachers-claiming-against-in-eligible-schools-are-told-they-are-in-eligible
- https://trello.com/c/lNrYqiYf/115-a-user-making-a-claim-and-no-longer-teaching-is-told-they-are-in-eligible