### PR TITLE
A teacher can provide their teacher reference number

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -63,7 +63,8 @@ class ClaimsController < ApplicationController
       :address_line_3,
       :address_line_4,
       :postcode,
-      :date_of_birth
+      :date_of_birth,
+      :teacher_reference_number
     )
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -7,6 +7,7 @@ class TslrClaim < ApplicationRecord
     "full-name",
     "address",
     "date-of-birth",
+    "teacher-reference-number",
     "complete",
   ].freeze
 
@@ -37,6 +38,7 @@ class TslrClaim < ApplicationRecord
   validates :address_line_3,    on: :address, presence: {message: "Enter your town or city"}
   validates :postcode,          on: :address, presence: {message: "Enter your postcode"}
   validates :date_of_birth,     on: :"date-of-birth", presence: {message: "Enter your date of birth"}
+  validates :teacher_reference_number, on: :"teacher-reference-number", presence: {message: "Enter your teacher reference number"}
 
   before_save :update_current_school, if: :employment_status_changed?
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -44,6 +44,10 @@ class TslrClaim < ApplicationRecord
 
   delegate :name, to: :claim_school, prefix: true, allow_nil: true
 
+  def teacher_reference_number=(teacher_reference_number)
+    super(teacher_reference_number.gsub(/\D/, ""))
+  end
+
   def page_sequence
     PAGE_SEQUENCE.dup.tap do |sequence|
       sequence.delete("current-school") if employed_at_claim_school?

--- a/app/views/claims/teacher_reference_number.html.erb
+++ b/app/views/claims/teacher_reference_number.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <h1 class="govuk-heading-xl">
+        <%= form.label :teacher_reference_number, "What is your teacher reference number?"  %>
+      </h1>
+
+      <span class="govuk-hint">This is on the certificate you got when you qualified as a teacher, or your school can tell you.</span>
+
+      <div class="govuk-form-group">
+        <%= form.text_field :teacher_reference_number, spellcheck: "false", class: "govuk-input" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/db/migrate/20190516105143_add_teacher_reference_number_to_tslr_claim.rb
+++ b/db/migrate/20190516105143_add_teacher_reference_number_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddTeacherReferenceNumberToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :teacher_reference_number, :string, limit: 11
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_092701) do
+ActiveRecord::Schema.define(version: 2019_05_16_105143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 2019_05_16_092701) do
     t.string "address_line_4", limit: 100
     t.string "postcode", limit: 11
     t.date "date_of_birth"
+    t.string "teacher_reference_number", limit: 11
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -49,6 +49,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.date_of_birth).to eq(Date.new(1990, 7, 3))
 
+    expect(page).to have_text("What is your teacher reference number?")
+    fill_in :tslr_claim_teacher_reference_number, with: "123456"
+    click_on "Continue"
+
+    expect(claim.reload.teacher_reference_number).to eql("123456")
+
     expect(page).to have_text("Claim complete")
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “teacher-reference-number” validation context" do
+    it "validates the presence of teacher_reference_number" do
+      expect(TslrClaim.new).not_to be_valid(:"teacher-reference-number")
+      expect(TslrClaim.new(teacher_reference_number: "123456")).to be_valid(:"teacher-reference-number")
+    end
+  end
+
   describe "#ineligible?" do
     subject { TslrClaim.new(claim_attributes).ineligible? }
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -63,6 +63,20 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  describe "#teacher_reference_number=" do
+    subject { TslrClaim.new(teacher_reference_number: teacher_reference_number).teacher_reference_number }
+
+    context "when the teacher reference number contains non digits" do
+      let(:teacher_reference_number) { "12\\23 /232 " }
+      it { is_expected.to eql("1223232") }
+    end
+
+    context "when the teacher reference number is all digits" do
+      let(:teacher_reference_number) { "1234567" }
+      it { is_expected.to eql("1234567") }
+    end
+  end
+
   describe "#ineligible?" do
     subject { TslrClaim.new(claim_attributes).ineligible? }
 


### PR DESCRIPTION
So that we can pay a teacher their teacher student loan re-imbursement payment we need to make sure they are really a teacher. Collecting their TRN is one of the ways we will achieve this.

At this stage we are validating the presence of the TRN and normalising it to digits only before saving it to the database.

At the moment we think that storing only digits is the right thing to do based on our understanding of TRNs, the DQT uses only digits to sign teacher in. We have contacted a subject matter expert at DfE to gain more understanding.

We think we may need to encrypt the value in the database at some point, but this work does not include that.

https://trello.com/c/01yTwht6