### PR TITLE
A teacher can provide their National Insurance number

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -64,7 +64,8 @@ class ClaimsController < ApplicationController
       :address_line_4,
       :postcode,
       :date_of_birth,
-      :teacher_reference_number
+      :teacher_reference_number,
+      :national_insurance_number,
     )
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -8,6 +8,7 @@ class TslrClaim < ApplicationRecord
     "address",
     "date-of-birth",
     "teacher-reference-number",
+    "national-insurance-number",
     "complete",
   ].freeze
 
@@ -42,6 +43,7 @@ class TslrClaim < ApplicationRecord
   validates :date_of_birth,     on: :"date-of-birth", presence: {message: "Enter your date of birth"}
   validates :teacher_reference_number, on: :"teacher-reference-number", presence: {message: "Enter your teacher reference number"}
   validate :trn_must_be_seven_digits
+  validates :national_insurance_number,   on: :"national-insurance-number", presence: {message: "Enter your National Insurance number"}
 
   before_save :update_current_school, if: :employment_status_changed?
   before_save :normalise_trn, if: :teacher_reference_number_changed?

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -33,17 +33,18 @@ class TslrClaim < ApplicationRecord
   belongs_to :claim_school, optional: true, class_name: "School"
   belongs_to :current_school, optional: true, class_name: "School"
 
-  validates :claim_school,      on: :"claim-school", presence: {message: "Select a school from the list"}
-  validates :qts_award_year,    on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
-  validates :employment_status, on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
-  validates :full_name,         on: :"full-name", presence: {message: "Enter your full name"}
-  validates :address_line_1,    on: :address, presence: {message: "Enter your building and street address"}
-  validates :address_line_3,    on: :address, presence: {message: "Enter your town or city"}
-  validates :postcode,          on: :address, presence: {message: "Enter your postcode"}
-  validates :date_of_birth,     on: :"date-of-birth", presence: {message: "Enter your date of birth"}
-  validates :teacher_reference_number, on: :"teacher-reference-number", presence: {message: "Enter your teacher reference number"}
+  validates :claim_school,              on: :"claim-school", presence: {message: "Select a school from the list"}
+  validates :qts_award_year,            on: :"qts-year", inclusion: {in: VALID_QTS_YEARS, message: "Select the academic year you were awarded qualified teacher status"}
+  validates :employment_status,         on: :"still-teaching", presence: {message: "Choose the option that describes your current employment status"}
+  validates :full_name,                 on: :"full-name", presence: {message: "Enter your full name"}
+  validates :address_line_1,            on: :address, presence: {message: "Enter your building and street address"}
+  validates :address_line_3,            on: :address, presence: {message: "Enter your town or city"}
+  validates :postcode,                  on: :address, presence: {message: "Enter your postcode"}
+  validates :date_of_birth,             on: :"date-of-birth", presence: {message: "Enter your date of birth"}
+  validates :teacher_reference_number,  on: :"teacher-reference-number", presence: {message: "Enter your teacher reference number"}
   validate :trn_must_be_seven_digits
-  validates :national_insurance_number,   on: :"national-insurance-number", presence: {message: "Enter your National Insurance number"}
+  validates :national_insurance_number, on: :"national-insurance-number", presence: {message: "Enter your National Insurance number"}
+  validate  :ni_number_is_correct_format
 
   before_save :update_current_school, if: :employment_status_changed?
   before_save :normalise_trn, if: :teacher_reference_number_changed?
@@ -88,6 +89,15 @@ class TslrClaim < ApplicationRecord
   end
 
   def normalise_ni_number
-    national_insurance_number.gsub!(/\s/, "")
+    self.national_insurance_number = normalised_ni_number
+  end
+
+  def normalised_ni_number
+    national_insurance_number.gsub(/\s/, "")
+  end
+
+  def ni_number_is_correct_format
+    errors.add(:national_insurance_number, "Enter a National Insurance number in the correct format") \
+      if national_insurance_number.present? && !normalised_ni_number.match(/\A[a-z]{2}[0-9]{6}[a-d]{1}\Z/i)
   end
 end

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -47,6 +47,7 @@ class TslrClaim < ApplicationRecord
 
   before_save :update_current_school, if: :employment_status_changed?
   before_save :normalise_trn, if: :teacher_reference_number_changed?
+  before_save :normalise_ni_number, if: :national_insurance_number_changed?
 
   delegate :name, to: :claim_school, prefix: true, allow_nil: true
 
@@ -84,5 +85,9 @@ class TslrClaim < ApplicationRecord
 
   def trn_must_be_seven_digits
     errors.add(:teacher_reference_number, "Teacher reference number must contain seven digits") if teacher_reference_number.present? && normalised_trn.length != TRN_LENGTH
+  end
+
+  def normalise_ni_number
+    national_insurance_number.gsub!(/\s/, "")
   end
 end

--- a/app/views/claims/national_insurance_number.html.erb
+++ b/app/views/claims/national_insurance_number.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <h1 class="govuk-heading-xl">
+        <%= form.label :national_insurance_number, "What is your National Insurance number?"  %>
+      </h1>
+
+      <span class="govuk-hint">It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.</span>
+
+      <div class="govuk-form-group">
+        <%= form.text_field :national_insurance_number, spellcheck: "false", class: "govuk-input" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/db/migrate/20190520095935_add_national_insurance_number_to_tslr_claim.rb
+++ b/db/migrate/20190520095935_add_national_insurance_number_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddNationalInsuranceNumberToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :national_insurance_number, :string, limit: 9
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_105143) do
+ActiveRecord::Schema.define(version: 2019_05_20_095935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2019_05_16_105143) do
     t.string "postcode", limit: 11
     t.date "date_of_birth"
     t.string "teacher_reference_number", limit: 11
+    t.string "national_insurance_number", limit: 9
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -55,6 +55,12 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.teacher_reference_number).to eql("1234567")
 
+    expect(page).to have_text("What is your National Insurance number?")
+    fill_in "National Insurance number", with: "QQ123456C"
+    click_on "Continue"
+
+    expect(claim.reload.national_insurance_number).to eq("QQ123456C")
+
     expect(page).to have_text("Claim complete")
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “national-insurance-number” validation context" do
+    it "validates the presence of national_insurance_number" do
+      expect(TslrClaim.new).not_to be_valid(:"national-insurance-number")
+      expect(TslrClaim.new(national_insurance_number: "QQ123456C")).to be_valid(:"national-insurance-number")
+    end
+  end
+
   describe "#ineligible?" do
     subject { TslrClaim.new(claim_attributes).ineligible? }
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving a record that has a National Insurance number" do
+    it "validates that the National Insurance number is in the correct format" do
+      expect(TslrClaim.new(national_insurance_number: "12 34 56 78 C")).not_to be_valid
+      expect(TslrClaim.new(national_insurance_number: "QQ 11 56 78 DE")).not_to be_valid
+
+      expect(TslrClaim.new(national_insurance_number: "QQ 34 56 78 C")).to be_valid
+    end
+  end
+
   describe "#national_insurance_number" do
     it "saves with white space stripped out" do
       claim = TslrClaim.create!(national_insurance_number: "QQ 12 34 56 C")

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -97,6 +97,14 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  describe "#national_insurance_number" do
+    it "saves with white space stripped out" do
+      claim = TslrClaim.create!(national_insurance_number: "QQ 12 34 56 C")
+
+      expect(claim.national_insurance_number).to eql("QQ123456C")
+    end
+  end
+
   describe "#ineligible?" do
     subject { TslrClaim.new(claim_attributes).ineligible? }
 


### PR DESCRIPTION
We need to capture the teacher's National Insurance number so that we can operate PAYE on their behalf.

We are validating the NI number is present and conforms to the correct format. We are removing whitespace before saving it to the database.

We think we may need to encrypt the value in the database at some point, but this work does not include that.

https://design-system.service.gov.uk/patterns/national-insurance-numbers/
https://trello.com/c/rwg4j8qH/