### PR TITLE
Time out claim session after 30 minutes

### DIFF
--- a/app/helpers/claims_helper.rb
+++ b/app/helpers/claims_helper.rb
@@ -17,4 +17,8 @@ module ClaimsHelper
   def tslr_guidance_url
     "https://www.gov.uk/guidance/teachers-student-loan-reimbursement-guidance-for-teachers-and-schools"
   end
+
+  def claim_timeout_in_minutes
+    ClaimsController::TIMEOUT_LENGTH_IN_MINUTES
+  end
 end

--- a/app/views/claims/timeout.html.erb
+++ b/app/views/claims/timeout.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Your session has ended due to inactivity
+    </h1>
+
+    <h2 class="govuk-heading-m">
+      Your session ended because you haven't done anything for <%= claim_timeout_in_minutes %> minutes
+    </h2>
+
+    <%= link_to "Start your application again", root_path, class: "govuk-button" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
     resources :claims, only: [:new, :create, :show, :update], param: :slug, path: "/claim"
   end
   get "/claim/ineligible", to: "claims#ineligible", as: :ineligible_claim
+  get "/claim/timeout", to: "claims#timeout", as: :timeout_claim
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,4 +61,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FeatureHelpers, type: :feature
+  config.include ActiveSupport::Testing::TimeHelpers
 end

--- a/spec/requests/claims_spec.rb
+++ b/spec/requests/claims_spec.rb
@@ -89,6 +89,13 @@ RSpec.describe "Claims", type: :request do
     end
   end
 
+  describe "claim#timeout" do
+    it "displays session timeout content" do
+      get timeout_claim_path
+      expect(response.body).to include("Your session has ended due to inactivity")
+    end
+  end
+
   describe "claims#update request" do
     context "when a claim is already in progress" do
       let(:in_progress_claim) { TslrClaim.order(:created_at).last }

--- a/spec/requests/timeout_spec.rb
+++ b/spec/requests/timeout_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe "Claim session timing out", type: :request do
+  let(:timeout_length_in_minutes) { ClaimsController::TIMEOUT_LENGTH_IN_MINUTES }
+
+  context "no actions performed for more than the timeout period" do
+    before { post claims_path }
+
+    let(:current_claim) { TslrClaim.order(:created_at).last }
+    let(:after_expiry) { timeout_length_in_minutes.minutes + 1.second }
+
+    it "clears the session and redirects to the timeout page" do
+      expect(session[:tslr_claim_id]).to eql current_claim.to_param
+
+      travel after_expiry do
+        put claim_path("qts-year"), params: {tslr_claim: {qts_award_year: "2014-2015"}}
+
+        expect(response).to redirect_to(timeout_claim_path)
+        expect(session[:tslr_claim_id]).to be_nil
+      end
+    end
+  end
+
+  context "no action performed just within the timeout period" do
+    before { post claims_path }
+
+    let(:current_claim) { TslrClaim.order(:created_at).last }
+    let(:before_expiry) { timeout_length_in_minutes.minutes - 2.seconds }
+
+    it "does not timeout the session" do
+      travel before_expiry do
+        put claim_path("qts-year"), params: {tslr_claim: {qts_award_year: "2014-2015"}}
+
+        expect(response).to redirect_to(claim_path("claim-school"))
+        expect(session[:tslr_claim_id]).to eql current_claim.to_param
+      end
+    end
+  end
+end


### PR DESCRIPTION
To help keep users’ information private we end the claim session after a fixed period of inactivity. We've picked 30 minutes for the time being but this may change in the future.

Note that we don't do anything with the incomplete claim data that will still be stored in the database just yet. At some point we want to ensure that this data is not retained, and perhaps deleted when the session is timed out, but until we have a way to distinguish between a fully completed claim and a partial one, we risk deleting completed claims by mistake. Capturing this elsewhere for a future story.

A JS-powered modal to warn users of the impending timeout is being worked on separately.