### PR TITLE
Email capture page

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -70,6 +70,7 @@ class ClaimsController < ApplicationController
       :date_of_birth,
       :teacher_reference_number,
       :national_insurance_number,
+      :email_address,
     )
   end
 

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -46,6 +46,10 @@ class TslrClaim < ApplicationRecord
   validate :trn_must_be_seven_digits
   validates :national_insurance_number, on: :"national-insurance-number", presence: {message: "Enter your National Insurance number"}
   validate  :ni_number_is_correct_format
+  validates :email_address, on: :"email-address", presence: {message: "Enter an email address"}
+  validates :email_address, format: {with: URI::MailTo::EMAIL_REGEXP, message: "Enter an email address in the correct format, like name@example.com"}, \
+                            length: {maximum: 256, message: "Email address must be 256 characters or less"}, \
+                            allow_nil: true
 
   before_save :update_current_school, if: :employment_status_changed?
   before_save :normalise_trn, if: :teacher_reference_number_changed?

--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -9,6 +9,7 @@ class TslrClaim < ApplicationRecord
     "date-of-birth",
     "teacher-reference-number",
     "national-insurance-number",
+    "email-address",
     "complete",
   ].freeze
 

--- a/app/views/claims/email_address.html.erb
+++ b/app/views/claims/email_address.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("shared/error_summary", instance: current_claim) if current_claim.errors.any? %>
+
+    <%= form_for current_claim, url: claim_path do |form| %>
+      <h1 class="govuk-heading-xl">
+        <%= form.label :email_address, "What is your email address?"  %>
+      </h1>
+
+      <span class="govuk-hint">We will only use your email address to update you about your claim.</span>
+
+      <div class="govuk-form-group">
+        <%= form.email_field :email_address, autocomplete: "email", spellcheck: "false", class: "govuk-input" %>
+      </div>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/db/migrate/20190521123756_add_email_address_to_tslr_claim.rb
+++ b/db/migrate/20190521123756_add_email_address_to_tslr_claim.rb
@@ -1,0 +1,5 @@
+class AddEmailAddressToTslrClaim < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tslr_claims, :email_address, :string, limit: 256
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_095935) do
+ActiveRecord::Schema.define(version: 2019_05_21_123756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_095935) do
     t.date "date_of_birth"
     t.string "teacher_reference_number", limit: 11
     t.string "national_insurance_number", limit: 9
+    t.string "email_address", limit: 256
     t.index ["claim_school_id"], name: "index_tslr_claims_on_claim_school_id"
     t.index ["current_school_id"], name: "index_tslr_claims_on_current_school_id"
     t.index ["employment_status"], name: "index_tslr_claims_on_employment_status"

--- a/spec/features/tslr_claim_spec.rb
+++ b/spec/features/tslr_claim_spec.rb
@@ -61,6 +61,13 @@ RSpec.feature "Teacher Student Loan Repayments claims" do
 
     expect(claim.reload.national_insurance_number).to eq("QQ123456C")
 
+    expect(page).to have_text("What is your email address?")
+    expect(page).to have_text("We will only use your email address to update you about your claim.")
+    fill_in "What is your email address?", with: "name@example.tld"
+    click_on "Continue"
+
+    expect(claim.reload.email_address).to eq("name@example.tld")
+
     expect(page).to have_text("Claim complete")
   end
 

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -114,6 +114,24 @@ RSpec.describe TslrClaim, type: :model do
     end
   end
 
+  context "when saving in the “email-address” validation context" do
+    it "validates the presence of email_address" do
+      expect(TslrClaim.new).not_to be_valid(:"email-address")
+      expect(TslrClaim.new(email_address: "name@example.tld")).to be_valid(:"email-address")
+    end
+  end
+
+  context "when saving a record that has a email address" do
+    it "validates that the value is in the correct format" do
+      expect(TslrClaim.new(email_address: "notan email@address.com")).not_to be_valid
+      expect(TslrClaim.new(email_address: "name@example.com")).to be_valid
+    end
+
+    it "checks that the email address in not longer than 256 characters" do
+      expect(TslrClaim.new(email_address: "#{"e" * 256}@example.com")).not_to be_valid
+    end
+  end
+
   describe "#ineligible?" do
     subject { TslrClaim.new(claim_attributes).ineligible? }
 


### PR DESCRIPTION
So we can update a teacher on the progress of their claim, we need to capture their email address.

Asking users for their email address is a recognised GOVUK pattern, so we have lots to reference:
https://design-system.service.gov.uk/patterns/email-addresses/

https://trello.com/c/GWRoD6Fz