### PR TITLE
Add length validation to the postcode field

### DIFF
--- a/app/models/tslr_claim.rb
+++ b/app/models/tslr_claim.rb
@@ -40,7 +40,8 @@ class TslrClaim < ApplicationRecord
   validates :full_name,                 on: :"full-name", presence: {message: "Enter your full name"}
   validates :address_line_1,            on: :address, presence: {message: "Enter your building and street address"}
   validates :address_line_3,            on: :address, presence: {message: "Enter your town or city"}
-  validates :postcode,                  on: :address, presence: {message: "Enter your postcode"}
+  validates :postcode,                  on: :address, presence: {message: "Enter your postcode"}, \
+                                        length: {maximum: 11, message: "Postcode must be 11 characters or less"}
   validates :date_of_birth,             on: :"date-of-birth", presence: {message: "Enter your date of birth"}
   validates :teacher_reference_number,  on: :"teacher-reference-number", presence: {message: "Enter your teacher reference number"}
   validate :trn_must_be_seven_digits

--- a/spec/models/tslr_claim_spec.rb
+++ b/spec/models/tslr_claim_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe TslrClaim, type: :model do
       valid_address_attributes = {address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "12345"}
       expect(TslrClaim.new(valid_address_attributes)).to be_valid(:address)
     end
+    it "validates the length of postcode is not greater than 11" do
+      expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M12345 23453WD")).not_to be_valid(:address)
+      expect(TslrClaim.new(address_line_1: "123 Main Street", address_line_3: "Twin Peaks", postcode: "M1 2WD")).to be_valid(:address)
+    end
   end
 
   context "when saving in the “date-of-birth” validation context" do


### PR DESCRIPTION
We have a database length limit of 11 characters on the postcode field but no validation to check it when submitting. Whilst unlikely this would cause an error in our app, so this adds a length validator to control the problem.

I was looking at production and hit this which raised a rollbar error, happy to not merge this one as collecting the address is temporary, but it's here if we want to.